### PR TITLE
Issue/5/realistic sky model

### DIFF
--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -101,7 +101,7 @@ def main():
     outdir = arguments.outdir
     if not os.path.isdir(outdir):
         os.makedirs(outdir)
-    prefix = config['eimage_prefix']
+    prefix = config['persistence']['eimage_prefix']
     phoSimGalaxyCatalog.write_images(nameRoot=os.path.join(outdir, prefix) +
                                      str(commands['obshistid']))
 

--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -12,6 +12,7 @@ from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.coordUtils import chipNameFromRaDec
 import desc.imsim
 
+
 def main():
     """
     Drive GalSim to simulate the LSST.
@@ -24,7 +25,8 @@ def main():
     parser.add_argument('--outdir', type=str, default='fits',
                         help='Output directory for eimage file')
     parser.add_argument('--sensor', type=str, default=None,
-                        help='Sensor to simulate, e.g., "R:2,2 S:1,1". If None, then simulate all sensors with sources on them')
+                        help='Sensor to simulate, e.g., "R:2,2 S:1,1".' +
+                        'If None, then simulate all sensors with sources on them')
     parser.add_argument('--config_file', type=str, default=None,
                         help="Config file. If None, the default config will be used.")
     parser.add_argument('--log_level', type=str,

--- a/data/default_imsim_configs
+++ b/data/default_imsim_configs
@@ -3,3 +3,12 @@ readout_time = 3.
 
 [persistence]
 eimage_prefix = lsst_e_
+
+[skyModel_params]
+B0 = 24.
+u = 0.282598538804
+g = 1.56492206349
+r = 1.3488785992
+i = 0.998783620839
+z = 0.699897205858
+y = 0.32665889564

--- a/python/desc/imsim/__init__.py
+++ b/python/desc/imsim/__init__.py
@@ -5,3 +5,4 @@ except ImportError:
     pass
 from .imSim import *
 from .imSim_class_factory import *
+from .skyModel import *

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -119,6 +119,7 @@ def parsePhoSimInstanceFile(fileName, numRows=None):
     phoSimObjectList = extract_objects(phoSimSources)
     return PhoSimInstanceCatalogContents(commands, phoSimObjectList)
 
+
 def extract_commands(df):
     """
     Extract the phosim commands and repackage as a simple dictionary,
@@ -143,6 +144,7 @@ def extract_commands(df):
     # Add bandpass for convenience
     commands['bandpass'] = 'ugrizy'[commands['filter']]
     return commands
+
 
 def extract_objects(df):
     """
@@ -213,6 +215,7 @@ def extract_objects(df):
         phosim_galaxies = extract_extinction(galaxies, phosim_galaxies, 5)
 
     return pd.concat((phosim_stars, phosim_galaxies), ignore_index=True)
+
 
 def extract_extinction(raw_df, object_df, ext_par_start):
     """
@@ -291,6 +294,7 @@ def extract_extinction(raw_df, object_df, ext_par_start):
     gc.collect()
     return result
 
+
 def validate_phosim_object_list(phoSimObjects):
     """
     Remove rows with column values that are known to cause problems with
@@ -360,6 +364,7 @@ def photometricParameters(phosim_commands):
                                  darkcurrent=0,
                                  bandpass=phosim_commands['bandpass'])
 
+
 def phosim_obs_metadata(phosim_commands):
     """
     Factory function to create an ObservationMetaData object based
@@ -390,6 +395,7 @@ def phosim_obs_metadata(phosim_commands):
     # Set the OpsimMetaData attribute with the obshistID info.
     obs_md.OpsimMetaData = {'obshistID': phosim_commands['obshistid']}
     return obs_md
+
 
 class ImSimConfiguration(object):
     """
@@ -478,6 +484,7 @@ def read_config(config_file=None):
             my_config.set_from_config(key, value)
     return my_config
 
+
 def get_logger(log_level):
     """
     Set up standard logging module and set lsst.log to the same log
@@ -498,6 +505,6 @@ def get_logger(log_level):
     if log_level == "CRITICAL":
         log_level = "FATAL"
     lsstLog.setLevel(lsstLog.getDefaultLoggerName(),
-                     eval('lsstLog.%s'% log_level))
+                     eval('lsstLog.%s' % log_level))
 
     return logger

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, division
 import os
 import sys
 import warnings
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 import logging
 import gc
 import ConfigParser
@@ -355,7 +355,7 @@ def photometricParameters(phosim_commands):
     config = get_config()
     nsnap = phosim_commands['nsnap']
     vistime = phosim_commands['vistime']
-    readout_time = config['readout_time']
+    readout_time = config['electronics_readout']['readout_time']
     exptime = (vistime - (nsnap-1)*readout_time)/float(nsnap)
     return PhotometricParameters(exptime=exptime,
                                  nexp=nsnap,
@@ -402,18 +402,21 @@ class ImSimConfiguration(object):
     Configuration parameters for the simulation.  All parameters are
     set in a class-level dictionary to ensure that they are the same
     across all class instances.
+
+    Individual parameter access is via section name:
+
+    >>> config = get_config()
+    >>> config['electronics_readout']['readout_time']
+    3.
     """
-    imsim_parameters = dict()
+    imsim_sections = defaultdict(dict)
 
-    def __getitem__(self, key):
-        return self.imsim_parameters[key]
+    def __getitem__(self, section_name):
+        return self.imsim_sections[section_name]
 
-    def __setitem__(self, key, value):
-        self.imsim_parameters[key] = value
-
-    def set_from_config(self, key, value):
+    def set_from_config(self, section_name, key, value):
         "Set the parameter value with the cast from a string applied."
-        self[key] = self.cast(value)
+        self[section_name][key] = self.cast(value)
 
     @staticmethod
     def cast(value):
@@ -468,20 +471,20 @@ def read_config(config_file=None):
 
     Returns
     -------
-    ImSimConfiguration object
+    dict ImSimConfiguration object
         An instance of ImSimConfiguration filled with the parameters from
         config_file.
     """
     my_config = ImSimConfiguration()
     cp = ConfigParser.SafeConfigParser()
+    cp.optionxform = str
     if config_file is None:
         config_file = os.path.join(lsstUtils.getPackageDir('imsim'),
                                    'data', 'default_imsim_configs')
     cp.read(config_file)
-    # Stuff all of the sections into the same dictionary for now.
     for section in cp.sections():
         for key, value in cp.items(section):
-            my_config.set_from_config(key, value)
+            my_config.set_from_config(section, key, value)
     return my_config
 
 

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -7,7 +7,7 @@ import gc
 from lsst.sims.utils import pupilCoordsFromRaDec
 
 from lsst.sims.GalSimInterface import GalSimStars, GalSimGalaxies
-from lsst.sims.GalSimInterface import ExampleCCDNoise, SNRdocumentPSF
+from lsst.sims.GalSimInterface import SNRdocumentPSF
 from desc.imsim.skyModel import ESOSkyModel
 
 __all__ = ['ImSimStars', 'ImSimGalaxies']
@@ -57,11 +57,14 @@ def imSim__init__(self, phosim_objects, obs_metadata, catalog_db=None):
     self.db_obj = type('DummyDB', (), dict(epoch=2000))
 
     # Add noise and sky background
-#    self.noise_and_background = ExampleCCDNoise(addNoise=True,
-#                                                addBackground=True)
-
-    # We need to know more than the basic info for Peter's sky model.
-    # Pass obs_metadata, chip etc...
+    # The simple code using the default lsst-GalSim interface would be:
+    #
+    #    self.noise_and_background = ExampleCCDNoise(addNoise=True,
+    #                                                addBackground=True)
+    #
+    # But, we need a more realistic sky model and we need to pass more than
+    # this basic info to use Peter Y's ESO sky model.
+    # We must pass obs_metadata, chip information etc...
     self.noise_and_background = ESOSkyModel(obs_metadata, addNoise=True,
                                             addBackground=True)
 

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -3,9 +3,12 @@ Code to generate imSim subclasses of GalSimBase subclasses.
 """
 from __future__ import absolute_import, print_function, division
 import gc
-from lsst.sims.GalSimInterface import GalSimStars, GalSimGalaxies, \
-    ExampleCCDNoise, SNRdocumentPSF
+
 from lsst.sims.utils import pupilCoordsFromRaDec
+
+from lsst.sims.GalSimInterface import GalSimStars, GalSimGalaxies
+from lsst.sims.GalSimInterface import ExampleCCDNoise, SNRdocumentPSF
+from desc.imsim.skyModel import ESOSkyModel
 
 __all__ = ['ImSimStars', 'ImSimGalaxies']
 
@@ -54,8 +57,13 @@ def imSim__init__(self, phosim_objects, obs_metadata, catalog_db=None):
     self.db_obj = type('DummyDB', (), dict(epoch=2000))
 
     # Add noise and sky background
-    self.noise_and_background = ExampleCCDNoise(addNoise=True,
-                                                addBackground=True)
+#    self.noise_and_background = ExampleCCDNoise(addNoise=True,
+#                                                addBackground=True)
+
+    # We need to know more than the basic info for Peter's sky model.
+    # Pass obs_metadata, chip etc...
+    self.noise_and_background = ESOSkyModel(obs_metadata, addNoise=True,
+                                            addBackground=True)
 
     # Add a PSF.  This one is taken from equation 30 of
     # www.astro.washington.edu/users/ivezic/Astr511/LSST_SNRdoc.pdf .

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -9,6 +9,7 @@ from lsst.sims.utils import pupilCoordsFromRaDec
 
 __all__ = ['ImSimStars', 'ImSimGalaxies']
 
+
 def imSim_class_factory(galsim_subclass):
     """
     Return a subclass of galsim_subclass that takes a pandas DataFrame
@@ -22,6 +23,7 @@ def imSim_class_factory(galsim_subclass):
                              ('__name__', imSim_class_name)]))
     imSim_class.__imSim_class__ = imSim_class
     return imSim_class
+
 
 def imSim__init__(self, phosim_objects, obs_metadata, catalog_db=None):
     """

--- a/python/desc/imsim/skyModel.py
+++ b/python/desc/imsim/skyModel.py
@@ -1,6 +1,9 @@
 '''
 Classes to represent realistic sky models.
+Note that this extends the default classes located in
+sims_GalSimInterface/python/lsst/sims/GalSimInterface/galSimNoiseAndBackground.py
 '''
+
 import numpy as np
 import astropy.units as u
 
@@ -9,11 +12,8 @@ import lsst.sims.skybrightness as skybrightness
 import galsim
 from lsst.sims.GalSimInterface.galSimNoiseAndBackground import NoiseAndBackgroundBase
 
-# from lsst.sims.photUtils import PhotometricParameters, LSSTdefaults
 
-
-# Code snippet from D. Kirkby.  Note the use of astropy units.  Should we remove
-# these or start doing this everywhere?
+# Code snippet from D. Kirkby.  Note the use of astropy units.
 def skyCountsPerSec(surface_brightness=21, filter_band='r',
                     effective_area=33.212*u.m**2, pixel_size=0.2*u.arcsec):
     # Lookup the zero point corresponding to 24 mag/arcsec**2
@@ -25,6 +25,8 @@ def skyCountsPerSec(surface_brightness=21, filter_band='r',
     return s0 * dB.to(1 / u.arcsec ** 2) * pixel_size ** 2 * effective_area
 
 
+# Here we are defining our own class derived from NoiseAndBackgroundBase for
+# use instead of ExampleCCDNoise
 class ESOSkyModel(NoiseAndBackgroundBase):
     """
     This class wraps the GalSim class CCDNoise.  This derived class returns
@@ -93,8 +95,8 @@ class ESOSkyModel(NoiseAndBackgroundBase):
         skyCounts = skyCountsPerSec(surface_brightness=skyMagnitude,
                                     filter_band=bandPassName)*exposureTime
 
-        print "Magnitude:", skyMagnitude
-        print "Brightness:", skyMagnitude, skyCounts
+        # print "Magnitude:", skyMagnitude
+        # print "Brightness:", skyMagnitude, skyCounts
 
         image = image.copy()
 

--- a/python/desc/imsim/skyModel.py
+++ b/python/desc/imsim/skyModel.py
@@ -1,0 +1,138 @@
+'''
+Classes to represent realistic sky models.
+'''
+import numpy as np
+import astropy.units as u
+
+import lsst.sims.skybrightness as skybrightness
+
+import galsim
+from lsst.sims.GalSimInterface.galSimNoiseAndBackground import NoiseAndBackgroundBase
+
+# from lsst.sims.photUtils import PhotometricParameters, LSSTdefaults
+
+
+# Code snippet from D. Kirkby.  Note the use of astropy units.  Should we remove
+# these or start doing this everywhere?
+def skyCountsPerSec(surface_brightness=21, filter_band='r',
+                    effective_area=33.212*u.m**2, pixel_size=0.2*u.arcsec):
+    # Lookup the zero point corresponding to 24 mag/arcsec**2
+    B0 = 24.
+    s0 = (dict(u=0.732, g=2.214, r=1.681, i=1.249, z=0.862, y=0.452)[filter_band] *
+          u.electron / u.s / u.m ** 2)
+    # Calculate the rate in detected electrons / second
+    dB = (surface_brightness - B0) * u.mag(1 / u.arcsec ** 2)
+    return s0 * dB.to(1 / u.arcsec ** 2) * pixel_size ** 2 * effective_area
+
+
+class ESOSkyModel(NoiseAndBackgroundBase):
+    """
+    This class wraps the GalSim class CCDNoise.  This derived class returns
+    a sky model based on the ESO model as implemented in
+    """
+
+    def __init__(self, obs_metadata, seed=None, addNoise=True, addBackground=True):
+        """
+        @param [in] addNoise is a boolean telling the wrapper whether or not
+        to add noise to the image
+
+        @param [in] addBackground is a boolean telling the wrapper whether
+        or not to add the skybackground to the image
+
+        @param [in] seed is an (optional) int that will seed the
+        random number generator used by the noise model. Defaults to None,
+        which causes GalSim to generate the seed from the system.
+        """
+
+        self.obs_metadata = obs_metadata
+
+        self.addNoise = addNoise
+        self.addBackground = addBackground
+
+        if seed is None:
+            self.randomNumbers = galsim.UniformDeviate()
+        else:
+            self.randomNumbers = galsim.UniformDeviate(seed)
+
+    def addNoiseAndBackground(self, image, bandpass=None, m5=None,
+                              FWHMeff=None,
+                              photParams=None):
+        """
+        This method actually adds the sky background and noise to an image.
+
+        Note: default parameters are defined in
+
+        sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
+        @param [in] image is the GalSim image object to which the background
+        and noise are being added.
+
+        @param [in] bandpass is a CatSim bandpass object (not a GalSim bandpass
+        object) characterizing the filter through which the image is being taken.
+
+        @param [in] FWHMeff is the FWHMeff in arcseconds
+
+        @param [in] photParams is an instantiation of the
+        PhotometricParameters class that carries details about the
+        photometric response of the telescope.  Defaults to None.
+
+        @param [out] the input image with the background and noise model added to it.
+        """
+
+        # calculate the sky background to be added to each pixel
+
+        skyModel = skybrightness.SkyModel(mags=True)
+        ra = np.array([self.obs_metadata.pointingRA])
+        dec = np.array([self.obs_metadata.pointingDec])
+        mjd = self.obs_metadata.mjd.TAI
+        skyModel.setRaDecMjd(ra, dec, mjd, degrees=True)
+
+        bandPassName = self.obs_metadata.bandpass
+        skyMagnitude = skyModel.returnMags()[bandPassName]
+
+        # skyCounts = calcSkyCountsPerPixelForM5(skyMagnitude, bandpass,
+        #                                        FWHMeff=FWHMeff,
+        #                                        photParams=photParams)
+
+        exposureTime = photParams.exptime*u.s
+
+        skyCounts = skyCountsPerSec(surface_brightness=skyMagnitude,
+                                    filter_band=bandPassName)*exposureTime
+
+        print "Magnitude:", skyMagnitude
+        print "Brightness:", skyMagnitude, skyCounts
+
+        image = image.copy()
+
+        if self.addBackground:
+            image += skyCounts
+
+            # if we are adding the skyCounts to the image,there is no need # to pass
+            # a skyLevel parameter to the noise model.  skyLevel is # just used to
+            # calculate the level of Poisson noise.  If the # sky background is
+            # included in the image, the Poisson noise # will be calculated from the
+            # actual image brightness.
+            skyLevel = 0.0
+
+        else:
+            skyLevel = skyCounts*photParams.gain
+
+        if self.addNoise:
+            noiseModel = self.getNoiseModel(skyLevel=skyLevel, photParams=photParams)
+            image.addNoise(noiseModel)
+
+        return image
+
+    def getNoiseModel(self, skyLevel=0.0, photParams=None):
+
+        """
+        This method returns the noise model implemented for this wrapper
+        class.
+
+        This is currently the same as implemented in ExampleCCDNoise.  This
+        routine can both Poisson fluctuate the background and add read noise.
+        We turn off the read noise by adjusting the parameters in the photParams.
+        """
+
+        return galsim.CCDNoise(self.randomNumbers, sky_level=skyLevel,
+                               gain=photParams.gain, read_noise=photParams.readnoise)

--- a/python/desc/imsim/skyModel.py
+++ b/python/desc/imsim/skyModel.py
@@ -4,6 +4,8 @@ Note that this extends the default classes located in
 sims_GalSimInterface/python/lsst/sims/GalSimInterface/galSimNoiseAndBackground.py
 '''
 
+from __future__ import absolute_import, division
+
 import numpy as np
 import astropy.units as u
 

--- a/python/desc/imsim/skyModel.py
+++ b/python/desc/imsim/skyModel.py
@@ -80,7 +80,6 @@ class ESOSkyModel(NoiseAndBackgroundBase):
         """
 
         # calculate the sky background to be added to each pixel
-
         skyModel = skybrightness.SkyModel(mags=True)
         ra = np.array([self.obs_metadata.pointingRA])
         dec = np.array([self.obs_metadata.pointingDec])
@@ -89,11 +88,6 @@ class ESOSkyModel(NoiseAndBackgroundBase):
 
         bandPassName = self.obs_metadata.bandpass
         skyMagnitude = skyModel.returnMags()[bandPassName]
-
-        # skyCounts = calcSkyCountsPerPixelForM5(skyMagnitude, bandpass,
-        #                                        FWHMeff=FWHMeff,
-        #                                        photParams=photParams)
-
         exposureTime = photParams.exptime*u.s
 
         skyCounts = skyCountsPerSec(surface_brightness=skyMagnitude,

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -30,13 +30,13 @@ class ImSimConfigurationTestCase(unittest.TestCase):
         "Test the read_config function."
         # Read the default config.
         config = desc.imsim.read_config()
-        self.assertAlmostEqual(config['readout_time'], 3.)
-        self.assertEqual(config['eimage_prefix'], 'lsst_e_')
+        self.assertAlmostEqual(config['electronics_readout']['readout_time'], 3.)
+        self.assertEqual(config['persistence']['eimage_prefix'], 'lsst_e_')
 
         # Read a different config file and show that the previous
         # instance reflects the new configuration.
         desc.imsim.read_config(self.test_config_file)
-        self.assertAlmostEqual(config['readout_time'], 2.)
+        self.assertAlmostEqual(config['electronics_readout']['readout_time'], 2.)
 
     def test_get_config(self):
         "Test the get_config function."
@@ -45,8 +45,8 @@ class ImSimConfigurationTestCase(unittest.TestCase):
 
         # Get an instance without re-reading the data.
         config = desc.imsim.get_config()
-        self.assertAlmostEqual(config['readout_time'], 3.)
-        self.assertEqual(config['eimage_prefix'], 'lsst_e_')
+        self.assertAlmostEqual(config['electronics_readout']['readout_time'], 3.)
+        self.assertEqual(config['persistence']['eimage_prefix'], 'lsst_e_')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_skyModel.py
+++ b/tests/test_skyModel.py
@@ -1,0 +1,41 @@
+"""
+Unit tests for skyModel code.
+"""
+from __future__ import absolute_import
+import os
+import unittest
+import ConfigParser
+import desc.imsim
+
+
+class SkyModelTestCase(unittest.TestCase):
+    """
+    TestCase class for skyModel module code.
+    """
+    def setUp(self):
+        self.test_config_file = 'test_config.txt'
+        self.zp_u = 0.282598538804
+        cp = ConfigParser.SafeConfigParser()
+        cp.optionxform = str
+        section = 'skyModel_params'
+        cp.add_section(section)
+        cp.set(section, 'B0', '24.')
+        cp.set(section, 'u', str(self.zp_u))
+        with open(self.test_config_file, 'wb') as output:
+            cp.write(output)
+
+    def tearDown(self):
+        try:
+            os.remove(self.test_config_file)
+        except OSError:
+            pass
+
+    def test_get_skyModel_params(self):
+        "Test the get_skyModel_params function."
+        desc.imsim.read_config(self.test_config_file)
+        pars = desc.imsim.get_skyModel_params()
+        self.assertAlmostEqual(pars['B0'], 24.)
+        self.assertAlmostEqual(pars['u'], self.zp_u)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request contains code to replace the exampleCCDNoise background class from the GalSim interface which uses a M5 level with @yoachim's ESO based sky model.  Peter's model returns the sky level in mag/arcsec^2 and @dkirkby's function skyCountsPerSec converts that into a count level using the exposure time in the instance catalog stored in photParams.exptime.  Note that David has calculated the zero points himself for a set of LSST filters. This should be changed to use the photUtils code.

Right now this just sets the whole skylevel based on the central pointing.  I think as an intermediate step we want to this per chip, and then probably eventually build a healpix table completely outside of the loop so we can assign each pixel.  But, I was thinking it might be useful to get this code in first and try it to confirm it gives reasonable signal/background levels and possibly put some options in for sky background choice.

Note there are also several small changes to meet PEP8 DM guidelines.