### PR TITLE
Configure ImSim to read mean ICRS RA, Dec from InstanceCatalogs

### DIFF
--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -69,6 +69,7 @@ def main():
         phosim_objects['chipName'] = \
             chipNameFromRaDec(phosim_objects['raICRS'].values,
                               phosim_objects['decICRS'].values,
+                              parallax=phosim_objects['parallax'].values,
                               camera=camera, obs_metadata=obs_md,
                               epoch=2000.0)
 

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -170,7 +170,7 @@ def extract_objects(df):
 
     columns = ('uniqueId', 'galSimType',
                'magNorm', 'sedFilepath', 'redshift',
-               'raICRS', 'decICRS',
+               'raJ2000', 'decJ2000',
                'halfLightRadius',
                'minorAxis',
                'majorAxis',
@@ -189,8 +189,8 @@ def extract_objects(df):
     phosim_stars['magNorm'] = pd.to_numeric(stars['MAG_NORM']).tolist()
     phosim_stars['sedFilepath'] = stars['SED_NAME'].tolist()
     phosim_stars['redshift'] = pd.to_numeric(stars['REDSHIFT']).tolist()
-    phosim_stars['raICRS'] = pd.to_numeric(stars['RA']).tolist()
-    phosim_stars['decICRS'] = pd.to_numeric(stars['DEC']).tolist()
+    phosim_stars['raJ2000'] = pd.to_numeric(stars['RA']).tolist()
+    phosim_stars['decJ2000'] = pd.to_numeric(stars['DEC']).tolist()
     phosim_stars['properMotionRa'] = pd.to_numeric(stars['PAR5']).tolist()
     phosim_stars['properMotionDec'] = pd.to_numeric(stars['PAR6']).tolist()
     phosim_stars['parallax'] = pd.to_numeric(stars['PAR7']).tolist()
@@ -208,8 +208,8 @@ def extract_objects(df):
     phosim_galaxies['magNorm'] = pd.to_numeric(galaxies['MAG_NORM']).tolist()
     phosim_galaxies['sedFilepath'] = galaxies['SED_NAME'].tolist()
     phosim_galaxies['redshift'] = pd.to_numeric(galaxies['REDSHIFT']).tolist()
-    phosim_galaxies['raICRS'] = pd.to_numeric(galaxies['RA']).tolist()
-    phosim_galaxies['decICRS'] = pd.to_numeric(galaxies['DEC']).tolist()
+    phosim_galaxies['raJ2000'] = pd.to_numeric(galaxies['RA']).tolist()
+    phosim_galaxies['decJ2000'] = pd.to_numeric(galaxies['DEC']).tolist()
     phosim_galaxies['majorAxis'] = \
         radiansFromArcsec(pd.to_numeric(galaxies['PAR1'])).tolist()
     phosim_galaxies['minorAxis'] = \

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -236,8 +236,13 @@ def extract_objects(df, header):
     phosim_galaxies['positionAngle'] = \
         (np.pi/180.*pd.to_numeric(galaxies['PAR3'])).tolist()
     phosim_galaxies['sindex'] = pd.to_numeric(galaxies['PAR4']).tolist()
+    n_gal = len(phosim_galaxies.raJ2000.values)
     phosim_galaxies = phosim_galaxies.assign(raICRS=phosim_galaxies.raJ2000,
-                                             decICRS=phosim_galaxies.decJ2000)
+                                             decICRS=phosim_galaxies.decJ2000,
+                                             properMotionRa=np.zeros(n_gal),
+                                             properMotionDec=np.zeros(n_gal),
+                                             parallax=np.zeros(n_gal),
+                                             radialVelocity=np.zeros(n_gal))
 
     if len(phosim_galaxies) > 0:
         phosim_galaxies = extract_extinction(galaxies, phosim_galaxies, 5)

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -218,6 +218,8 @@ def extract_objects(df):
     phosim_galaxies['positionAngle'] = \
         (np.pi/180.*pd.to_numeric(galaxies['PAR3'])).tolist()
     phosim_galaxies['sindex'] = pd.to_numeric(galaxies['PAR4']).tolist()
+    phosim_galaxies = phosim_galaxies.assign(raICRS=phosim_galaxies.raJ2000,
+                                             decICRS=phosim_galaxies.decJ2000)
     if len(phosim_galaxies) > 0:
         phosim_galaxies = extract_extinction(galaxies, phosim_galaxies, 5)
 

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -174,7 +174,9 @@ def extract_objects(df):
                'halfLightRadius',
                'minorAxis',
                'majorAxis',
-               'positionAngle', 'sindex')
+               'positionAngle', 'sindex',
+               'properMotionRa', 'properMotionDec',
+               'parallax', 'radialVelocity')
 
     # Process point sources and galaxies separately.
     source_type = 'point'
@@ -189,6 +191,10 @@ def extract_objects(df):
     phosim_stars['redshift'] = pd.to_numeric(stars['REDSHIFT']).tolist()
     phosim_stars['raICRS'] = pd.to_numeric(stars['RA']).tolist()
     phosim_stars['decICRS'] = pd.to_numeric(stars['DEC']).tolist()
+    phosim_stars['properMotionRa'] = pd.to_numeric(stars['PAR5']).tolist()
+    phosim_stars['properMotionDec'] = pd.to_numeric(stars['PAR6']).tolist()
+    phosim_stars['parallax'] = pd.to_numeric(stars['PAR7']).tolist()
+    phosim_stars['radialVelocity'] = pd.to_numeric(stars['PAR8']).tolist()
     if len(phosim_stars) > 0:
         phosim_stars = extract_extinction(stars, phosim_stars, 1)
 

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -47,10 +47,15 @@ def imSim__init__(self, phosim_objects, obs_metadata, catalog_db=None):
     else:
         self.obs_metadata = obs_metadata
 
-    xPupil, yPupil = pupilCoordsFromRaDec(phosim_objects['raICRS'].values,
-                                          phosim_objects['decICRS'].values,
+    xPupil, yPupil = pupilCoordsFromRaDec(phosim_objects['raJ2000'].values,
+                                          phosim_objects['decJ2000'].values,
+                                          pm_ra = phosim_objects['properMotionRa'].values,
+                                          pm_dec = phosim_objects['properMotionDec'].values,
+                                          parallax = phosim_objects['parallax'].values,
+                                          v_rad = phosim_objects['radialVelocity'].values,
                                           obs_metadata=obs_metadata,
                                           epoch=2000.0)
+
     self.phosim_objects = phosim_objects.assign(x_pupil=xPupil, y_pupil=yPupil)
     gc.collect()
 

--- a/tests/test_instcat_parser.py
+++ b/tests/test_instcat_parser.py
@@ -47,8 +47,8 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
 
         star = instcat_contents.objects.query("uniqueId==1046817878020").iloc[0]
         self.assertEqual(star['galSimType'], 'pointSource')
-        self.assertAlmostEqual(star['raICRS'], 31.2400746)
-        self.assertAlmostEqual(star['decICRS'], -10.09365)
+        self.assertAlmostEqual(star['raJ2000'], 31.2400746)
+        self.assertAlmostEqual(star['decJ2000'], -10.09365)
         self.assertEqual(star['sedFilepath'], 'starSED/phoSimMLT/lte033-4.5-1.0a+0.4.BT-Settl.spec.gz')
 
         galaxy = instcat_contents.objects.query("uniqueId==34308924793883").iloc[0]


### PR DESCRIPTION
This should adjust ImSim to read in mean ICRS RA, Dec from InstanceCatalogs and then apply proper motion correctly before placing objects on the focal plane.

I haven't run this all the way through to image generation, yet, but the unit tests pass.