### PR TITLE
Fix ConfigParser to work with Python 3.

### DIFF
--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -8,7 +8,16 @@ import warnings
 from collections import namedtuple, defaultdict
 import logging
 import gc
-import ConfigParser
+
+# python_future no longer handles configparser as of 0.16.
+# This is needed for PY2/3 compatabiloty.
+try:
+    from configparser import ConfigParser
+    from configparser import SafeConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+    from ConfigParser import SafeConfigParser
+
 import numpy as np
 import pandas as pd
 import lsst.log as lsstLog
@@ -516,7 +525,7 @@ def read_config(config_file=None):
         config_file.
     """
     my_config = ImSimConfiguration()
-    cp = ConfigParser.SafeConfigParser()
+    cp = SafeConfigParser()
     cp.optionxform = str
     if config_file is None:
         config_file = os.path.join(lsstUtils.getPackageDir('imsim'),

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -528,7 +528,7 @@ def read_config(config_file=None):
         config_file.
     """
     my_config = ImSimConfiguration()
-    cp = configparser.SafeConfigParser()
+    cp = configparser.ConfigParser()
     cp.optionxform = str
     if config_file is None:
         config_file = os.path.join(lsstUtils.getPackageDir('imsim'),

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -12,11 +12,10 @@ import gc
 # python_future no longer handles configparser as of 0.16.
 # This is needed for PY2/3 compatabiloty.
 try:
-    from configparser import ConfigParser
-    from configparser import SafeConfigParser
+    import configparser
 except ImportError:
-    from ConfigParser import ConfigParser
-    from ConfigParser import SafeConfigParser
+    # python 2 backwards-compatibility
+    import ConfigParser as configparser
 
 import numpy as np
 import pandas as pd
@@ -529,7 +528,7 @@ def read_config(config_file=None):
         config_file.
     """
     my_config = ImSimConfiguration()
-    cp = SafeConfigParser()
+    cp = configparser.SafeConfigParser()
     cp.optionxform = str
     if config_file is None:
         config_file = os.path.join(lsstUtils.getPackageDir('imsim'),

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -35,6 +35,7 @@ __all__ = ['parsePhoSimInstanceFile', 'PhosimInstanceCatalogParseError',
 class PhosimInstanceCatalogParseError(RuntimeError):
     "Exception class for instance catalog parser."
 
+
 PhoSimInstanceCatalogContents = namedtuple('PhoSimInstanceCatalogContents',
                                            ('commands', 'objects'))
 
@@ -116,13 +117,15 @@ def parsePhoSimInstanceFile(fileName, numRows=None):
     command_set = set(phoSimHeaderCards['STRING'])
     missing_commands = _required_commands - command_set
     if missing_commands:
-        message = "\nRequired commands that are missing from the instance catalog %s:\n   " % fileName + "\n   ".join(missing_commands)
+        message = "\nRequired commands that are missing from the instance catalog %s:\n   " \
+            % fileName + "\n   ".join(missing_commands)
         raise PhosimInstanceCatalogParseError(message)
 
     # Report on commands that are not part of the required set.
     extra_commands = command_set - _required_commands
     if extra_commands:
-        message = "\nExtra commands in the instance catalog %s that are not in the required set:\n   " % fileName + "\n   ".join(extra_commands)
+        message = "\nExtra commands in the instance catalog %s that are not in the required set:\n   " \
+            % fileName + "\n   ".join(extra_commands)
         warnings.warn(message)
 
     # Turn the list of commands into a dictionary.
@@ -185,7 +188,8 @@ def extract_objects(df, header):
                        sersic2d='sersic')
     invalid_types = set(df['SOURCE_TYPE']) - set(valid_types)
     if invalid_types:
-        warnings.warn("Instance catalog contains unhandled source types:\n%s\nSkipping these." % '\n'.join(invalid_types))
+        warnings.warn("Instance catalog contains unhandled source types:\n%s\nSkipping these."
+                      % '\n'.join(invalid_types))
 
     columns = ('uniqueId', 'galSimType',
                'magNorm', 'sedFilepath', 'redshift',

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -11,6 +11,7 @@ except ImportError:
     import ConfigParser as configparser
 import desc.imsim
 
+
 class ImSimConfigurationTestCase(unittest.TestCase):
     """
     TestCase class for configuration parameter code.
@@ -51,6 +52,7 @@ class ImSimConfigurationTestCase(unittest.TestCase):
         config = desc.imsim.get_config()
         self.assertAlmostEqual(config['electronics_readout']['readout_time'], 3.)
         self.assertEqual(config['persistence']['eimage_prefix'], 'lsst_e_')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -4,7 +4,11 @@ Unit tests for imSim configuration parameter code.
 from __future__ import print_function, absolute_import
 import os
 import unittest
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    # python 2 backwards-compatibility
+    import ConfigParser as configparser
 import desc.imsim
 
 class ImSimConfigurationTestCase(unittest.TestCase):
@@ -13,7 +17,7 @@ class ImSimConfigurationTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.test_config_file = 'test_config.txt'
-        cp = ConfigParser.SafeConfigParser()
+        cp = configparser.SafeConfigParser()
         section = 'electronics_readout'
         cp.add_section(section)
         cp.set(section, 'readout_time', '2')

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -17,7 +17,7 @@ class ImSimConfigurationTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.test_config_file = 'test_config.txt'
-        cp = configparser.SafeConfigParser()
+        cp = configparser.ConfigParser()
         section = 'electronics_readout'
         cp.add_section(section)
         cp.set(section, 'readout_time', '2')

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -21,7 +21,7 @@ class ImSimConfigurationTestCase(unittest.TestCase):
         section = 'electronics_readout'
         cp.add_section(section)
         cp.set(section, 'readout_time', '2')
-        with open(self.test_config_file, 'wb') as output:
+        with open(self.test_config_file, 'w') as output:
             cp.write(output)
 
     def tearDown(self):

--- a/tests/test_imSim_class_factory.py
+++ b/tests/test_imSim_class_factory.py
@@ -6,6 +6,7 @@ import os
 import unittest
 import desc.imsim
 
+
 class ImSimClassFactoryTestCase(unittest.TestCase):
     "TestCase class for imSim_class_factory."
     def setUp(self):
@@ -26,6 +27,7 @@ class ImSimClassFactoryTestCase(unittest.TestCase):
         self.assertEqual(stars.column_by_name('galSimType')[0], 'pointSource')
         self.assertAlmostEqual(stars.column_by_name('x_pupil')[0], -0.0008283)
         self.assertAlmostEqual(stars.column_by_name('y_pupil')[0], -0.00201296)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_instcat_parser.py
+++ b/tests/test_instcat_parser.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import desc.imsim
 
+
 class InstanceCatalogParserTestCase(unittest.TestCase):
     """
     TestCase class for instance catalog parsing code.
@@ -144,6 +145,7 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
         self.assertEqual(len(rejected.query("minorAxis > majorAxis")), 1)
         self.assertEqual(len(rejected.query("magNorm > 50")), 1)
         self.assertEqual(len(rejected.query("galacticAv==0 and galacticRv==0")), 4)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function
 import unittest
 import desc.imsim
 
+
 class LoggingTestCase(unittest.TestCase):
     "TestCase class for logging."
 
@@ -20,6 +21,7 @@ class LoggingTestCase(unittest.TestCase):
                                     "DEBUG INFO WARN ERROR CRITICAL".split()):
             logger = desc.imsim.get_logger(log_level)
             self.assertEqual(logger.level, level)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_skyModel.py
+++ b/tests/test_skyModel.py
@@ -25,7 +25,7 @@ class SkyModelTestCase(unittest.TestCase):
         cp.add_section(section)
         cp.set(section, 'B0', '24.')
         cp.set(section, 'u', str(self.zp_u))
-        with open(self.test_config_file, 'wb') as output:
+        with open(self.test_config_file, 'w') as output:
             cp.write(output)
 
     def tearDown(self):

--- a/tests/test_skyModel.py
+++ b/tests/test_skyModel.py
@@ -19,7 +19,7 @@ class SkyModelTestCase(unittest.TestCase):
     def setUp(self):
         self.test_config_file = 'test_config.txt'
         self.zp_u = 0.282598538804
-        cp = configparser.SafeConfigParser()
+        cp = configparser.ConfigParser()
         cp.optionxform = str
         section = 'skyModel_params'
         cp.add_section(section)

--- a/tests/test_skyModel.py
+++ b/tests/test_skyModel.py
@@ -4,7 +4,11 @@ Unit tests for skyModel code.
 from __future__ import absolute_import
 import os
 import unittest
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    # python 2 backwards-compatibility
+    import ConfigParser as configparser
 import desc.imsim
 
 
@@ -15,7 +19,7 @@ class SkyModelTestCase(unittest.TestCase):
     def setUp(self):
         self.test_config_file = 'test_config.txt'
         self.zp_u = 0.282598538804
-        cp = ConfigParser.SafeConfigParser()
+        cp = configparser.SafeConfigParser()
         cp.optionxform = str
         section = 'skyModel_params'
         cp.add_section(section)

--- a/tests/test_skyModel.py
+++ b/tests/test_skyModel.py
@@ -41,5 +41,6 @@ class SkyModelTestCase(unittest.TestCase):
         self.assertAlmostEqual(pars['B0'], 24.)
         self.assertAlmostEqual(pars['u'], self.zp_u)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change is needed for Python 2/3 compatibility. As of version 0.16 of python-future, the ConfigParser package name alias is no longer functional. This code block is based on the way EUPS now handles this.

Could someone also check this still works with python 2?
