### PR TITLE
Apply WL shears

### DIFF
--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -12,11 +12,8 @@ import numpy as np
 from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.coordUtils import chipNameFromRaDec
 from lsst.sims.GalSimInterface import SNRdocumentPSF
-try:
-    from lsst.sims.GalSimInterface import Kolmogorov_and_Gaussian_PSF
-except ImportError:
-    # in case we are running with an old version of lsst_sims
-    pass
+from lsst.sims.GalSimInterface import LSSTCameraWrapper, GalSimCameraWrapper
+from lsst.sims.GalSimInterface import Kolmogorov_and_Gaussian_PSF
 from desc.imsim.skyModel import ESOSkyModel
 import desc.imsim
 
@@ -117,8 +114,8 @@ def main():
     # But, we need a more realistic sky model and we need to pass more than
     # this basic info to use Peter Y's ESO sky model.
     # We must pass obs_metadata, chip information etc...
-    phoSimStarCatalog.noise_and_background = ESOSkyModel(obs_md, addNoise=True,
-                                                         addBackground=True)
+    phoSimStarCatalog.noise_and_background \
+        = ESOSkyModel(obs_md, addNoise=True, addBackground=True)
 
     # Add a PSF.
     if arguments.psf.lower() == "doublegaussian":
@@ -146,6 +143,11 @@ def main():
                            "%s" % arguments.psf)
 
     phoSimStarCatalog.camera = camera
+    try:
+        phoSimStarCatalog.camera_wrapper = LSSTCameraWrapper()
+    except NameError:
+        pass
+
     phoSimStarCatalog.get_fitsFiles()
 
     # Now galaxies

--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -143,11 +143,7 @@ def main():
                            "%s" % arguments.psf)
 
     phoSimStarCatalog.camera = camera
-    try:
-        phoSimStarCatalog.camera_wrapper = LSSTCameraWrapper()
-    except NameError:
-        pass
-
+    phoSimStarCatalog.camera_wrapper = LSSTCameraWrapper()
     phoSimStarCatalog.get_fitsFiles()
 
     # Now galaxies

--- a/python/desc/imsim/camera_readout.py
+++ b/python/desc/imsim/camera_readout.py
@@ -69,7 +69,7 @@ class ImageSource(object):
         """
         self.eimage = fits.HDUList()
         self.eimage.append(fits.PrimaryHDU(image_array))
-        self.eimage_data = self.eimage[0].data
+        self.eimage_data = self.eimage[0].data.transpose()
 
         self.exptime = exptime
         self.sensor_id = sensor_id

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -251,6 +251,9 @@ def extract_objects(df, header):
     phosim_galaxies['positionAngle'] = \
         (np.pi/180.*pd.to_numeric(galaxies['PAR3'])).tolist()
     phosim_galaxies['sindex'] = pd.to_numeric(galaxies['PAR4']).tolist()
+    phosim_galaxies['gamma1'] = pd.to_numeric(galaxies['GAMMA1']).tolist()
+    phosim_galaxies['gamma2'] = pd.to_numeric(galaxies['GAMMA2']).tolist()
+    phosim_galaxies['kappa'] = pd.to_numeric(galaxies['KAPPA']).tolist()
     n_gal = len(phosim_galaxies.raJ2000.values)
     phosim_galaxies = phosim_galaxies.assign(raICRS=phosim_galaxies.raJ2000,
                                              decICRS=phosim_galaxies.decJ2000,

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -251,8 +251,8 @@ def extract_objects(df, header):
     phosim_galaxies['positionAngle'] = \
         (np.pi/180.*pd.to_numeric(galaxies['PAR3'])).tolist()
     phosim_galaxies['sindex'] = pd.to_numeric(galaxies['PAR4']).tolist()
-    phosim_galaxies['gamma1'] = pd.to_numeric(galaxies['GAMMA1']).tolist()
-    phosim_galaxies['gamma2'] = pd.to_numeric(galaxies['GAMMA2']).tolist()
+    phosim_galaxies['shear1'] = pd.to_numeric(galaxies['GAMMA1']).tolist()
+    phosim_galaxies['shear2'] = pd.to_numeric(galaxies['GAMMA2']).tolist()
     phosim_galaxies['kappa'] = pd.to_numeric(galaxies['KAPPA']).tolist()
     n_gal = len(phosim_galaxies.raJ2000.values)
     phosim_galaxies = phosim_galaxies.assign(raICRS=phosim_galaxies.raJ2000,

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -251,8 +251,8 @@ def extract_objects(df, header):
     phosim_galaxies['positionAngle'] = \
         (np.pi/180.*pd.to_numeric(galaxies['PAR3'])).tolist()
     phosim_galaxies['sindex'] = pd.to_numeric(galaxies['PAR4']).tolist()
-    phosim_galaxies['shear1'] = pd.to_numeric(galaxies['GAMMA1']).tolist()
-    phosim_galaxies['shear2'] = pd.to_numeric(galaxies['GAMMA2']).tolist()
+    phosim_galaxies['gamma1'] = pd.to_numeric(galaxies['GAMMA1']).tolist()
+    phosim_galaxies['gamma2'] = pd.to_numeric(galaxies['GAMMA2']).tolist()
     phosim_galaxies['kappa'] = pd.to_numeric(galaxies['KAPPA']).tolist()
     n_gal = len(phosim_galaxies.raJ2000.values)
     phosim_galaxies = phosim_galaxies.assign(raICRS=phosim_galaxies.raJ2000,

--- a/tests/shear_test_instcat.txt
+++ b/tests/shear_test_instcat.txt
@@ -1,0 +1,27 @@
+#comment
+rightascension 45.005
+declination 0.005
+mjd 59797.2854090
+altitude 43.6990272
+azimuth 73.7707957
+filter 2
+rotskypos 0.000
+rottelpos 0.000
+dist2moon 145.1095257
+moonalt -11.1383568
+moondec -18.7702120
+moonphase 59.6288830
+moonra 230.9832941
+nsnap 2
+obshistid 161899
+seed 161899
+seeing 0.7613760
+rawSeeing 0.7613760
+FWHMgeom 1.210734
+FWHMeff 1.409653
+sunalt -59.1098785
+vistime 33.0000000
+object 0 45.00 0.00 17. flatSED/sed_flat.txt.gz 0 0.0 0.0 0.0 0 0 sersic2d 0.5 0.5 0 1 CCM 0.100000001 3.0999999 CCM 0.0594432589 3.1
+object 1 45.01 0.00 17. flatSED/sed_flat.txt.gz 0 0.0 0.0 0.5 0 0 sersic2d 0.5 0.5 0 1 CCM 0.100000001 3.0999999 CCM 0.0594432589 3.1
+object 2 45.00 0.01 17. flatSED/sed_flat.txt.gz 0 0.5 0.0 0.0 0 0 sersic2d 0.5 0.5 0 1 CCM 0.100000001 3.0999999 CCM 0.0594432589 3.1
+object 3 45.01 0.01 17. flatSED/sed_flat.txt.gz 0 0.0 0.5 0.0 0 0 sersic2d 0.5 0.5 0 1 CCM 0.100000001 3.0999999 CCM 0.0594432589 3.1

--- a/tests/test_camera_readout.py
+++ b/tests/test_camera_readout.py
@@ -42,7 +42,7 @@ class ImageSourceTestCase(unittest.TestCase):
     def test_create_from_eimage(self):
         "Test the .create_from_eimage static method."
         self.assertAlmostEqual(self.image_source.exptime, 30.)
-        self.assertTupleEqual(self.image_source.eimage_data.shape, (4000, 4072))
+        self.assertTupleEqual(self.image_source.eimage_data.shape, (4072, 4000))
         self.assertTupleEqual(
             self.image_source.amp_images['R22_S11_C00'].getArray().shape,
             (2020, 532))


### PR DESCRIPTION
This addresses #17.   Since I needed to make [corresponding changes to `sims_GalSimInterface`](https://github.com/lsst/sims_GalSimInterface/pull/35), I also made the updates for #68 .

Here's a comparison of the output of `imsim.py` using [shear_test_instcat.txt](https://github.com/LSSTDESC/imSim/files/1412472/shear_test_instcat.txt) (left image) with the corresponding sheared galaxies rendered using direct calls to `galsim` (right image, [galsim_shear_test_py](https://github.com/LSSTDESC/imSim/files/1412480/galsim_shear_test_py.txt)):

![shear_comparison](https://user-images.githubusercontent.com/1994473/31967408-b143bca8-b8c2-11e7-88c1-ca1a5eece576.png)

