### PR TITLE
Use visit number and detector name to set random seed for generating cosmic rays

### DIFF
--- a/python/desc/imsim/cosmic_rays.py
+++ b/python/desc/imsim/cosmic_rays.py
@@ -147,7 +147,7 @@ class CosmicRays(list):
         Parameters
         ----------
         seed: int
-            The seed be between 0 and 2**32 - 1
+            The seed must be between 0 and 2**32 - 1
         """
         self.rng = np.random.RandomState(seed)
 

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -681,9 +681,14 @@ def add_cosmic_rays(gs_interpreter, phot_params):
                                'data', 'cosmic_ray_catalog.fits.gz')
     crs = CosmicRays.read_catalog(catalog, ccd_rate=ccd_rate)
 
+    # Retrieve the visit number for the random seeds.
+    visit = gs_interpreter.obs_metadata.OpsimMetaData['obshistID']
+
     exptime = phot_params.nexp*phot_params.exptime
     for name, image in gs_interpreter.detectorImages.items():
         imarr = copy.deepcopy(image.array)
+        # Set the random number seed for painting the CRs.
+        crs.set_seed(CosmicRays.get_seed(visit, name))
         gs_interpreter.detectorImages[name] = \
             galsim.Image(crs.paint(imarr, exptime=exptime), wcs=image.wcs)
 

--- a/tests/test_cosmic_rays.py
+++ b/tests/test_cosmic_rays.py
@@ -43,6 +43,26 @@ class CosmicRaysTestCase(unittest.TestCase):
         imarr = crs.paint_cr(imarr, index=0, pixel=(0, 0))
         np.testing.assert_array_equal(self.test_image, imarr)
 
+    def test_cr_rng_seed(self):
+        "Test that the CRs are reproducible for a given seed."
+        nxy = 100
+        num_crs = 10
+        visit = 141134
+        sensor = "R:2,2 S:1,1"
+        seed = CosmicRays.get_seed(visit, sensor)
+        self.assertIsInstance(seed, int)
+
+        crs1 = CosmicRays.read_catalog(self.test_catalog)
+        crs1.set_seed(seed)
+        imarr1 = np.zeros((nxy, nxy))
+        imarr1 = crs1.paint(imarr1, num_crs=num_crs)
+
+        crs2 = CosmicRays.read_catalog(self.test_catalog)
+        crs2.set_seed(seed)
+        imarr2 = np.zeros((nxy, nxy))
+        imarr2 = crs2.paint(imarr2, num_crs=num_crs)
+
+        np.testing.assert_array_equal(imarr1, imarr2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cosmic_rays.py
+++ b/tests/test_cosmic_rays.py
@@ -52,6 +52,8 @@ class CosmicRaysTestCase(unittest.TestCase):
         seed = CosmicRays.get_seed(visit, sensor)
         self.assertIsInstance(seed, int)
 
+        # Check that CRs are the same for two different CosmicRays
+        # objects with the same seed.
         crs1 = CosmicRays.read_catalog(self.test_catalog)
         crs1.set_seed(seed)
         imarr1 = np.zeros((nxy, nxy))
@@ -63,6 +65,14 @@ class CosmicRaysTestCase(unittest.TestCase):
         imarr2 = crs2.paint(imarr2, num_crs=num_crs)
 
         np.testing.assert_array_equal(imarr1, imarr2)
+
+        # Check that CRs differ for different sensors.
+        crs3 = CosmicRays.read_catalog(self.test_catalog)
+        crs3.set_seed(CosmicRays.get_seed(visit, "R:2,4 S:1,2"))
+        imarr3 = np.zeros((nxy, nxy))
+        imarr3 = crs2.paint(imarr3, num_crs=num_crs)
+        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
+                                 imarr1, imarr3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will ensure that CRs are the same for a given visit and also vary from sensor to sensor.