### PR TITLE
Add basic centroid file capability.

### DIFF
--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -30,6 +30,8 @@ parser.add_argument('--disable_sensor_model', default=False,
                     help='disable sensor effects')
 parser.add_argument('--file_id', type=str, default=None,
                     help='ID string to use for checkpoint and centroid filenames.')
+parser.add_argument('--create_centroid_file', default=False, action="store_true",
+                    help='Write centroid file(s).')
 parser.add_argument('--seed', type=int, default=267,
                     help='integer used to seed random number generator')
 parser.add_argument('--processes', type=int, default=1,
@@ -43,12 +45,12 @@ obs_md = desc.imsim.phosim_obs_metadata(commands)
 psf = desc.imsim.make_psf(args.psf, obs_md, log_level=args.log_level)
 
 sensor_list = args.sensors.split('^') if args.sensors is not None \
-              else args.sensors
+    else args.sensors
 
 apply_sensor_model = not args.disable_sensor_model
 
 image_simulator \
-    = desc.imsim.ImageSimulator(args.file, psf,
+    = desc.imsim.ImageSimulator(args.file, args.create_centroid_file, psf,
                                 numRows=args.numrows,
                                 config=args.config_file,
                                 seed=args.seed,

--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -50,13 +50,14 @@ sensor_list = args.sensors.split('^') if args.sensors is not None \
 apply_sensor_model = not args.disable_sensor_model
 
 image_simulator \
-    = desc.imsim.ImageSimulator(args.file, args.create_centroid_file, psf,
+    = desc.imsim.ImageSimulator(args.file, psf,
                                 numRows=args.numrows,
                                 config=args.config_file,
                                 seed=args.seed,
                                 outdir=args.outdir,
                                 sensor_list=sensor_list,
                                 apply_sensor_model=apply_sensor_model,
+                                create_centroid_file=args.create_centroid_file,
                                 file_id=args.file_id,
                                 log_level=args.log_level)
 

--- a/data/default_imsim_configs
+++ b/data/default_imsim_configs
@@ -6,6 +6,7 @@ full_well = 1e5
 
 [persistence]
 eimage_prefix = lsst_e_
+centroid_prefix = centroid_
 
 [cosmic_rays]
 ccd_rate = 8

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -34,7 +34,7 @@ class ImageSimulator:
     Class to manage the parallel simulation of sensors using the
     multiprocessing module.
     """
-    def __init__(self, instcat, psf, numRows=None, config=None, seed=267,
+    def __init__(self, instcat, create_centroid_file, psf, numRows=None, config=None, seed=267,
                  outdir='fits', sensor_list=None, apply_sensor_model=True,
                  file_id=None, log_level='WARN'):
         """
@@ -69,6 +69,7 @@ class ImageSimulator:
             Logging level ('DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL').
         """
         self.config = read_config(config)
+        self.create_centroid_file = create_centroid_file
         self.psf = psf
         self.outdir = outdir
         self.obs_md, self.phot_params, sources \
@@ -124,6 +125,10 @@ class ImageSimulator:
                     .restore_checkpoint(self.camera_wrapper,
                                         self.phot_params,
                                         self.obs_md)
+
+            if self.create_centroid_file is True:
+                self.gs_interpreter.centroid_base_name = self.outdir + '/' \
+                    + self.config['persistence']['centroid_prefix']
 
     @staticmethod
     def checkpoint_file(file_id, det_name):
@@ -279,6 +284,9 @@ class SimulateSensor:
         obsHistID = str(image_simulator.obs_md.OpsimMetaData['obshistID'])
         gs_interpreter.writeImages(nameRoot=os.path.join(outdir, prefix)
                                    + obsHistID)
+
+        gs_interpreter.close_centroid_files()
+
 
 #        # The image for the sensor-visit has been drawn, so delete the
 #        # checkpoint file.

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -285,6 +285,8 @@ class SimulateSensor:
         gs_interpreter.writeImages(nameRoot=os.path.join(outdir, prefix)
                                    + obsHistID)
 
+        # Write out the centroid files if they were made.
+        gs_interpreter.write_centroid_files()
         gs_interpreter.close_centroid_files()
 
 

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -289,8 +289,6 @@ class SimulateSensor:
 
         # Write out the centroid files if they were made.
         gs_interpreter.write_centroid_files()
-        gs_interpreter.close_centroid_files()
-
 
 #        # The image for the sensor-visit has been drawn, so delete the
 #        # checkpoint file.

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -127,8 +127,8 @@ class ImageSimulator:
                                         self.obs_md)
 
             if self.create_centroid_file is True:
-                self.gs_interpreter.centroid_base_name = self.outdir + '/' \
-                    + self.config['persistence']['centroid_prefix']
+                self.gs_interpreters[det_name].centroid_base_name = self.outdir \
+                    + '/' + self.config['persistence']['centroid_prefix']
 
     @staticmethod
     def checkpoint_file(file_id, det_name):

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -128,8 +128,9 @@ class ImageSimulator:
                                         self.obs_md)
 
             if self.create_centroid_file is True:
-                self.gs_interpreters[det_name].centroid_base_name = self.outdir \
-                    + '/' + self.config['persistence']['centroid_prefix']
+                self.gs_interpreters[det_name].centroid_base_name = \
+                    os.path.join(self.outdir,
+                                 self.config['persistence']['centroid_prefix'])
 
     @staticmethod
     def checkpoint_file(file_id, det_name):

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -29,14 +29,15 @@ __all__ = ['ImageSimulator']
 # image_simulator to self so that it is available in the callbacks.
 image_simulator = None
 
+
 class ImageSimulator:
     """
     Class to manage the parallel simulation of sensors using the
     multiprocessing module.
     """
-    def __init__(self, instcat, create_centroid_file, psf, numRows=None, config=None, seed=267,
+    def __init__(self, instcat, psf, numRows=None, config=None, seed=267,
                  outdir='fits', sensor_list=None, apply_sensor_model=True,
-                 file_id=None, log_level='WARN'):
+                 create_centroid_file=False, file_id=None, log_level='WARN'):
         """
         Parameters
         ----------
@@ -169,7 +170,7 @@ class ImageSimulator:
         prefix = self.config['persistence']['eimage_prefix']
         obsHistID = str(self.obs_md.OpsimMetaData['obshistID'])
         return os.path.join(self.outdir, prefix + '_'.join(
-            (obsHistID, detector.fileName, self.obs_md.bandpass +'.fits')))
+            (obsHistID, detector.fileName, self.obs_md.bandpass + '.fits')))
 
     def run(self, processes=1, wait_time=None):
         """

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -127,7 +127,7 @@ class ImageSimulator:
                                         self.phot_params,
                                         self.obs_md)
 
-            if self.create_centroid_file is True:
+            if self.create_centroid_file:
                 self.gs_interpreters[det_name].centroid_base_name = \
                     os.path.join(self.outdir,
                                  self.config['persistence']['centroid_prefix'])


### PR DESCRIPTION
I am working on adding more pixel level truth to the simulation but thought it would be useful to first add basic 'centroid file' capability (requested in #32).  

My work on adding information based on what each object looks like on the sensor is currently adding a lot of CPU run time and I need more work to optimize it.  So, this initial PR uses only truth information about the objects in the centroid file.   This makes it more difficult to use this to do imSim/PhoSim validation comparisons (because the PhoSim centroid values are average X and Y values on the sensor) but it is better for comparing catalog truth with the sensor since the true values are not affected by being near the edge of the sensor etc. Eventually we may want both. 

This code will make centroid files corresponding to each fits file in the output directory.  For example:

```
wasabi:fits % ls
centroid_197356_R22_S01_r.txt	lsst_e_197356_R22_S01_r.fits
centroid_197356_R22_S10_r.txt	lsst_e_197356_R22_S10_r.fits
centroid_197356_R22_S11_r.txt	lsst_e_197356_R22_S11_r.fits
centroid_197356_R22_S12_r.txt	lsst_e_197356_R22_S12_r.fits
centroid_197356_R22_S21_r.txt	lsst_e_197356_R22_S21_r.fits
```

With a small piece of code this can be converted into a ds9 region file for overlay.  This pandas code example puts a circle at each true object position with the radius scaled by the log of the number of photons for one of the centroid files:

```
import math
import numpy as np
import pandas as pd

centroids = pd.read_csv('fits/centroid_197356_R22_S11_r.txt', delim_whitespace=True, comment="#")

with open('region_file.reg','w') as outfile:
    outfile.write('physical\n')
    centroids.query('Photons>0').to_string(outfile, columns=['xpos','ypos','Photons'], 
                                           header=False, index=False,
                                           formatters=['circle {:10.3f}'.format,
                                                       '{:10.3f}'.format,
                                                       lambda x: '{:10.3f}'.format(math.log(x))])
```

Loading this regions file after loading the fits file results in:

<img width="860" alt="screen shot 2018-05-06 at 12 12 42 am" src="https://user-images.githubusercontent.com/5562740/39664760-2480bb06-50c3-11e8-8ae7-630acb935cc4.png">

To my eye, there is a small shift between the circle centers and the objects.  I'm not sure if this is a plotting issue, a misunderstanding on my part of the variables I used, or some small bug in the code.

The imSim code only sets the options to turn this on and sets the file prefix in the config file.  The code to open, close and write to the files is in sims_GalSimInterface. I will open a separate PR there.

Currently, this code only is in the non-sensor version of the GalSimInterpreter class.  I would like some feedback from @jchiang87, @rmjarvis and @danielsf before I add much more to make  sure this approach seems reasonable to people.

I started by making this look like a PhoSim centroid file since I thought this might make things easier on the people running the pipeline but in principle we could also add more information into the file. 