### PR TITLE
Expose the Silicon Sensor brighter fatter strength parameter to the imSim UI.

### DIFF
--- a/data/default_imsim_configs
+++ b/data/default_imsim_configs
@@ -3,6 +3,7 @@ readout_time = 3.
 
 [ccd]
 full_well = 1e5
+bf_strength = 1.0
 
 [persistence]
 eimage_prefix = lsst_e_

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -114,11 +114,16 @@ class ImageSimulator:
                                       noise_and_background,
                                       epoch=2000.0, seed=seed,
                                       apply_sensor_model=self.apply_sensor_model)
+
             self.gs_interpreters[det_name].sky_bg_per_pixel \
                 = noise_and_background.sky_counts(det_name)
             self.gs_interpreters[det_name].setPSF(PSF=self.psf)
+
             if self.apply_sensor_model:
                 add_treering_info(self.gs_interpreters[det_name].detectors)
+                self.gs_interpreters[det_name].bf_strength \
+                    = self.config['ccd']['bf_strength']
+
             if file_id is not None:
                 self.gs_interpreters[det_name].checkpoint_file \
                     = self.checkpoint_file(file_id, det_name)


### PR DESCRIPTION
The galsim.SiliconSensor class has a strength parameter that scales the size of the BF effect with 1.0 being the default amount in the model. These changes (and matching changes in sims_GalSimInterface) allow one to adjust the scaling parameter by editing a parameter in an imSim config file like this:

```
[ccd]
full_well = 1e5
bf_strength = 1.0
```

This is generally useful for tuning and may be necessary for run 2.0i depending on the outcome of issue #251.