### PR TITLE
test for and fix bleed trail wrapping

### DIFF
--- a/python/desc/imsim/bleed_trails.py
+++ b/python/desc/imsim/bleed_trails.py
@@ -166,7 +166,12 @@ class BleedCharge:
         try:
             bled_charge = min(self.full_well - self.imarr[0, xpix],
                               self.excess_charge)
-            self.imarr[0, xpix] += bled_charge
+            if xpix >= 0:
+                # Restrict charge redistribution to positive xpix
+                # values to avoid wrapping the bleed trail to the
+                # other end of the channel.  Charge bled off the end
+                # will still be removed from the excess charge pool.
+                self.imarr[0, xpix] += bled_charge
             self.excess_charge -= bled_charge
         except IndexError:
             # Trying to bleed charge past end of the channel, so

--- a/tests/test_bleed_trails.py
+++ b/tests/test_bleed_trails.py
@@ -171,6 +171,14 @@ class BleedTrailTestCase(unittest.TestCase):
         for i in range(-1, -10, -1):
             self.assertEqual(bled_channel[i], 0)
 
+        # Check the bleed stop end of the channel to be sure charge
+        # doesn't wrap the other way.
+        channel = np.zeros(self.nypix, dtype=np.int)
+        channel[-1] = 20*self.full_well
+        bled_channel = desc.imsim.bleed_channel(channel, self.full_well)
+        for i in range(10):
+            self.assertEqual(bled_channel[i], 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bleed_trails.py
+++ b/tests/test_bleed_trails.py
@@ -149,5 +149,30 @@ class BleedTrailTestCase(unittest.TestCase):
         max_pix_right = max(eimage_save.getArray()[:, nx//2:].ravel())
         self.assertLess(max_pix_right, self.full_well)
 
+    def test_bleed_trail_wrap(self):
+        """
+        In issue #153, it was noted that bleed trails extending to
+        the sensor edge will wrap around to the midline bleed stop
+        and continue bleeding from the opposite end of the amplifier
+        segment.  Test against this by placing well above saturated
+        signal in a pixel at the 0-index end of the channel and ensure
+        that no signal appears at the high-index end of the channel.
+        """
+        channel = np.zeros(self.nypix, dtype=np.int)
+        star_center = 1000
+        star_size = 20
+        # Put an initial signal in the first pixel in this channel
+        # so that the bleed trail would try to extend +/-10 pixels
+        # in each direction.
+        channel[0] = 20*self.full_well
+
+        bled_channel = desc.imsim.bleed_channel(channel, self.full_well)
+
+        # Check that the pixels at the other end of the channel are
+        # still empty.
+        for i in range(-1, -10, -1):
+            self.assertEqual(bled_channel[i], 0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bleed_trails.py
+++ b/tests/test_bleed_trails.py
@@ -159,8 +159,6 @@ class BleedTrailTestCase(unittest.TestCase):
         that no signal appears at the high-index end of the channel.
         """
         channel = np.zeros(self.nypix, dtype=np.int)
-        star_center = 1000
-        star_size = 20
         # Put an initial signal in the first pixel in this channel
         # so that the bleed trail would try to extend +/-10 pixels
         # in each direction.


### PR DESCRIPTION
Here's the fixed version of the image that showed the bleed trail wrapping in the [Slack posting](https://lsstc.slack.com/archives/C978LTJGN/p1536245590000100):
![v211182-r02-s11-i_bleed_trail_fix](https://user-images.githubusercontent.com/1994473/45176946-67ec9900-b1c6-11e8-86e8-7192bf899038.png)
