### PR TITLE
Fix optics psf

### DIFF
--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -14,7 +14,8 @@ from .optical_system import OpticalZernikes, mock_deviations
 class OptWF(object):
     def __init__(self, rng, wavelength, gsparams=None):
         u = galsim.UniformDeviate(rng)
-        self.deviations = mock_deviations(seed=int(u()*2**31))
+        deviationsFudgeFactor = 3.0
+        self.deviations = deviationsFudgeFactor*mock_deviations(seed=int(u()*2**31))
         self.oz = OpticalZernikes(self.deviations)
         self.dynamic = False
         self.reversible = True

--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -30,7 +30,8 @@ class OptWF(object):
 
     def _wavefront_gradient(self, u, v, t, theta):
         z = self.oz.cartesian_coeff(theta[0]/galsim.degrees, theta[1]/galsim.degrees)
-        Z = galsim.OpticalScreen(diam=8.36, obscuration=0.61, aberrations=[0]*4+list(z))
+        Z = galsim.OpticalScreen(diam=8.36, obscuration=0.61, aberrations=[0]*4+list(z),
+                                 annular_zernike=True)
         return Z._wavefront_gradient(u, v, t, theta)
 
     def _stepK(self, **kwargs):

--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -29,7 +29,7 @@ class OptWF(object):
                 and self.stepk == rhs.stepk)
 
     def _wavefront_gradient(self, u, v, t, theta):
-        z = self.oz.cartesian_coeff(theta[0].rad, theta[1].rad)
+        z = self.oz.cartesian_coeff(theta[0]/galsim.degrees, theta[1]/galsim.degrees)
         Z = galsim.OpticalScreen(diam=8.36, obscuration=0.61, aberrations=[0]*4+list(z))
         return Z._wavefront_gradient(u, v, t, theta)
 

--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -14,6 +14,11 @@ from .optical_system import OpticalZernikes, mock_deviations
 class OptWF(object):
     def __init__(self, rng, wavelength, gsparams=None):
         u = galsim.UniformDeviate(rng)
+        # Fudge factor below comes from an attempt to force the PSF ellipticity distribution to
+        # match more closely the targets in the SRD (not be too round).  (See the discussion at
+        # https://github.com/LSSTDESC/DC2-production/issues/259).  Since the values in the
+        # mock_deviations function currently rely on a small set of simulations (7), this was deemed
+        # reasonable.
         deviationsFudgeFactor = 3.0
         self.deviations = deviationsFudgeFactor*mock_deviations(seed=int(u()*2**31))
         self.oz = OpticalZernikes(self.deviations)

--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -29,7 +29,12 @@ class OptWF(object):
                 and self.stepk == rhs.stepk)
 
     def _wavefront_gradient(self, u, v, t, theta):
-        z = self.oz.cartesian_coeff(theta[0]/galsim.degrees, theta[1]/galsim.degrees)
+        # remap theta to prevent extrapolation beyond a radius of 1.708 degrees, which is the
+        # radius of the outermost sampling point.
+        fudgeFactor = 1.708/2.04
+
+        z = self.oz.cartesian_coeff(theta[0]/galsim.degrees*fudgeFactor,
+                                    theta[1]/galsim.degrees*fudgeFactor)
         Z = galsim.OpticalScreen(diam=8.36, obscuration=0.61, aberrations=[0]*4+list(z),
                                  annular_zernike=True)
         return Z._wavefront_gradient(u, v, t, theta)

--- a/python/desc/imsim/optical_system.py
+++ b/python/desc/imsim/optical_system.py
@@ -249,7 +249,7 @@ class OpticalZernikes:
         """
 
         x, y = self.cartesian_coords
-        basis = zernikeBasis(22, x, y)
+        basis = zernikeBasis(15, x, y)
 
         out = []
         for coefficient in self.sampling_coeff:


### PR DESCRIPTION
This PR adds a couple of bug fixes and a couple of other changes in an attempt to make the imSim optics PSF correct and more realistic.  See the discussion here: https://github.com/LSSTDESC/DC2-production/issues/259.  

I'm certainly open to the idea of only implementing a subset of these commits.  Given the time constraints, it'd be great to have as many eyes on this as possible.

Some output implementing these changes can be seen here: https://github.com/LSSTDESC/DC2-production/issues/259#issuecomment-421166639

Note that the above plot was created outside of ImSim, though I did use the atmPSF.py and optical_system.py in my external test.