### PR TITLE
Add gaussian psf to AtmosphericPSF

### DIFF
--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -47,8 +47,8 @@ parser.add_argument('--psf_file', type=str, default=None,
                     "if not, a PSF will be created and saved to that filename.")
 parser.add_argument('--image_path', type=str, default=None,
                     help="search path for FITS postage stamp images."
-                    "This will be prepended to any existing IMSIM_IMAGE_PATH"
-                    "environment variable, for which $CWD is included by"
+                    "This will be prepended to any existing IMSIM_IMAGE_PATH "
+                    "environment variable, for which $CWD is included by "
                     "default.")
 
 args = parser.parse_args()

--- a/data/default_imsim_configs
+++ b/data/default_imsim_configs
@@ -45,3 +45,9 @@ gamma2_sign = -1
 
 [objects]
 sort_magnorm = True
+
+[psf]
+# FWHM in arcsec of the Gaussian to convolve with the baseline
+# AtmosphericPSF + OptWF PSF to account for additional instrumental
+# effects.
+gaussianFWHM = 0.3

--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -131,7 +131,8 @@ class AtmosphericPSF(PSFbase):
                 and self.t0 == rhs.t0
                 and self.exptime == rhs.exptime
                 and self.atm == rhs.atm
-                and self.aper == rhs.aper)
+                and self.aper == rhs.aper
+                and self.gaussianFWHM == rhs.gaussianFWHM)
 
     @staticmethod
     def _vkSeeing(r0_500, wavelength, L0):

--- a/python/desc/imsim/atmPSF.py
+++ b/python/desc/imsim/atmPSF.py
@@ -230,7 +230,7 @@ class AtmosphericPSF(PSFbase):
             gsparams=gsparams)
         if self.gaussianFWHM > 0.0:
             psf = galsim.Convolve(
-                psf,
-                galsim.Gaussian(fwhm=self.gaussianFWHM, gsparams=gsparams)
+                galsim.Gaussian(fwhm=self.gaussianFWHM, gsparams=gsparams),
+                psf
             )
         return psf

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -986,6 +986,11 @@ def make_psf(psf_name, obs_md, log_level='WARN', rng=None, **kwds):
             # Use the 'seed' value from the instance catalog for the rng
             # used by the atmospheric PSF.
             rng = galsim.UniformDeviate(obs_md.OpsimMetaData['seed'])
+        if 'gaussianFWHM' not in kwds:
+            # Retrieve the additional instrumental PSF FWHM from the
+            # imSim config file.
+            config = get_config()
+            kwds['gaussianFWHM'] = config['psf']['gaussianFWHM']
         logger = get_logger(log_level, 'psf')
         psf = AtmosphericPSF(airmass=my_airmass,
                              rawSeeing=rawSeeing,

--- a/tests/test_atmPSF.py
+++ b/tests/test_atmPSF.py
@@ -1,23 +1,29 @@
 import unittest
 
 import numpy as np
+import galsim
 
 from desc.imsim.atmPSF import AtmosphericPSF
 
 class AtmPSF(unittest.TestCase):
     def test_r0_500(self):
-        """Test that _seeing_resid has the API fsolve wants."""
-        for wavelength in [300.0, 500.0, 1100.0]:
-            for L0 in [10.0, 25.0, 100.0]:
-                for target_seeing in [0.5, 0.7, 1.0]:
-                    r0s = [0.1, 0.2]
-                    np.testing.assert_array_equal(
-                        np.hstack([
-                            AtmosphericPSF._seeing_resid(r0s[0], wavelength, L0, target_seeing),
-                            AtmosphericPSF._seeing_resid(r0s[1], wavelength, L0, target_seeing),
-                        ]),
-                        AtmosphericPSF._seeing_resid(r0s, wavelength, L0, target_seeing)
-                    )
+        """Test that inversion of the Tokovinin fitting formula for r0_500 works."""
+        np.random.seed(57721)
+        for _ in range(100):
+            airmass = np.random.uniform(1.001, 1.5)
+            rawSeeing = np.random.uniform(0.5, 1.5)
+            band = 'ugrizy'[np.random.randint(6)]
+            rng = galsim.BaseDeviate(np.random.randint(2**32))
+            atmPSF = AtmosphericPSF(airmass, rawSeeing, band, rng, screen_size=6.4)
+
+            wlen = dict(u=365.49, g=480.03, r=622.20, i=754.06, z=868.21, y=991.66)[band]
+            targetFWHM = rawSeeing * airmass**0.6 * (wlen/500)**(-0.3)
+
+            r0_500 = atmPSF.atm.r0_500_effective
+            L0 = atmPSF.atm[0].L0
+            vkFWHM = AtmosphericPSF._vkSeeing(r0_500, wlen, L0)
+
+            np.testing.assert_allclose(targetFWHM, vkFWHM, atol=1e-3, rtol=0)
 
 
 if __name__ == '__main__':

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -39,7 +39,7 @@ class PsfTestCase(unittest.TestCase):
     def test_atm_psf_config(self):
         """
         Test that the psf delivered by make_psf correctly applies the
-        config file value for gaussianPSF for the AtmosphericPSF.
+        config file value for gaussianFWHM as input to the AtmosphericPSF.
         """
         config = desc.imsim.get_config()
         psf_name = 'Atmospheric'

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -14,6 +14,9 @@ class PsfTestCase(unittest.TestCase):
     def setUp(self):
         self.test_dir = os.path.join(os.environ['IMSIM_DIR'], 'tests',
                                      'psf_tests_dir')
+        instcat = os.path.join(os.environ['IMSIM_DIR'], 'tests',
+                               'tiny_instcat.txt')
+        self.obs_md, _, _ = desc.imsim.parsePhoSimInstanceFile(instcat, ())
         os.makedirs(self.test_dir)
 
     def tearDown(self):
@@ -26,15 +29,37 @@ class PsfTestCase(unittest.TestCase):
         Test that the different imSim PSFs are saved and retrieved
         correctly.
         """
-        instcat = os.path.join(os.environ['IMSIM_DIR'], 'tests',
-                               'tiny_instcat.txt')
-        obs_md, _, _ = desc.imsim.parsePhoSimInstanceFile(instcat, ())
         for psf_name in ("DoubleGaussian", "Kolmogorov", "Atmospheric"):
-            psf = desc.imsim.make_psf(psf_name, obs_md, screen_scale=6.4)
+            psf = desc.imsim.make_psf(psf_name, self.obs_md, screen_scale=6.4)
             psf_file = os.path.join(self.test_dir, '{}.pkl'.format(psf_name))
             desc.imsim.save_psf(psf, psf_file)
             psf_retrieved = desc.imsim.load_psf(psf_file)
             self.assertEqual(psf, psf_retrieved)
+
+    def test_atm_psf_config(self):
+        """
+        Test that the psf delivered by make_psf correctly applies the
+        config file value for gaussianPSF for the AtmosphericPSF.
+        """
+        config = desc.imsim.get_config()
+        psf_name = 'Atmospheric'
+        screen_scale = 6.4
+        # PSF with gaussianFWHM explicitly set to zero.
+        psf_0 = desc.imsim.make_psf(psf_name, self.obs_md,
+                                    gaussianFWHM=0.,
+                                    screen_scale=screen_scale)
+
+        # PSF with gaussianFWHM explicitly set to config file value.
+        psf_c = desc.imsim.make_psf(psf_name, self.obs_md,
+                                    gaussianFWHM=config['psf']['gaussianFWHM'],
+                                    screen_scale=screen_scale)
+
+        # PSF using the config file value implicitly.
+        psf = desc.imsim.make_psf(psf_name, self.obs_md,
+                                  screen_scale=screen_scale)
+
+        self.assertEqual(psf, psf_c)
+        self.assertNotEqual(psf, psf_0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR follows from the discussion on slack channel #desc-dm-dc2 around Jan 9-11, 2019.  It adds an option to convolve in an additional Gaussian PSF to the AtmosphericPSF model to account for otherwise unmodeled effects, such as dome seeing, polishing errors, vibration, and other errors listed in document LTS-124.

I also took the opportunity to switch from using `fsolve` to invert the Tokovinin fitting formula for r0_500 to `bisect`, which I've found to be more robust.  I also changed the code to target the seeing at the specific filter effective wavelength being drawn instead of the seeing at 500 nm.  These two changes are mostly aesthetic, yielding delivered FWHM differences around ~0.01 arcseconds.