### PR TITLE
Remove unnecessary obs_lsst instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,6 @@ execute the `setup imsim` command, and that command can be issued from
 any directory.  The `scons` build step needs only to be re-run if a
 new command line executable is added to the `bin.src` folder.
 
-### obs_lsst
-The CCD pixel and LSST focalplane geometries are obtained from the
-lsst/obs_lsst package, which is not yet part of the standard LSST
-distribution.  Until it is, you'll need to clone a copy, set it up,
-and build:
-```
-$ git clone https://github.com/lsst/obs_lsst.git
-$ cd obs_lsst
-$ setup -r . -j
-$ scons
-```
-
 ## Usage
 The executables in the `bin` folder should be in your path and so
 should be runnable directly from the command line:


### PR DESCRIPTION
Now that obs_lsst is included in lsst_sims, we no longer need to tell people to checkout and set it up.