### PR TITLE
Fix Atmospheric PSF pickling

### DIFF
--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -45,6 +45,10 @@ parser.add_argument('--psf_file', type=str, default=None,
                     "If the file exists, the psf will be loaded from that "
                     "file, ignoring the --psf option; "
                     "if not, a PSF will be created and saved to that filename.")
+parser.add_argument('--psf_screen_file', type=str, default=None,
+                    help="File containing shared memory portion of "
+                    "AtmosphericPSF.  Required if reading/writing psf_file and "
+                    "the psf type is Atmospheric.")
 parser.add_argument('--image_path', type=str, default=None,
                     help="search path for FITS postage stamp images."
                     "This will be prepended to any existing IMSIM_IMAGE_PATH "
@@ -72,9 +76,10 @@ obs_md = desc.imsim.phosim_obs_metadata(commands)
 if args.psf_file is None or not os.path.isfile(args.psf_file):
     psf = desc.imsim.make_psf(args.psf, obs_md, log_level=args.log_level)
     if args.psf_file is not None:
-        desc.imsim.save_psf(psf, args.psf_file)
+        desc.imsim.save_psf(psf, args.psf_file, args.psf_screen_file)
 else:
-    psf = desc.imsim.load_psf(args.psf_file, log_level=args.log_level)
+    psf = desc.imsim.load_psf(args.psf_file, args.psf_screen_file,
+                              log_level=args.log_level)
 
 sensor_list = args.sensors.split('^') if args.sensors is not None \
     else args.sensors

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -886,7 +886,7 @@ def make_psf(psf_name, obs_md, log_level='WARN', rng=None, **kwds):
                              logger=logger, **kwds)
     return psf
 
-def save_psf(psf, outfile):
+def save_psf(psf, outfile, screen_file=None):
     """
     Save the psf as a pickle file.
     """
@@ -895,11 +895,15 @@ def save_psf(psf, outfile):
         psf.logger = None
     with open(outfile, 'wb') as output:
         pickle.dump(psf, output)
+    if screen_file:
+        galsim.phase_screens.writeScreenShare(screen_file)
 
-def load_psf(psf_file, log_level='INFO'):
+def load_psf(psf_file, screen_file=None, log_level='INFO'):
     """
     Load a psf from a pickle file.
     """
+    if screen_file:
+        galsim.phase_screens.readScreenShare(screen_file)
     with open(psf_file, 'rb') as fd:
         psf = pickle.load(fd)
 

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -6,7 +6,10 @@ import os
 import sys
 import warnings
 from collections import namedtuple, defaultdict
-import pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import logging
 import traceback
 import gc

--- a/python/desc/imsim/process_monitor.py
+++ b/python/desc/imsim/process_monitor.py
@@ -6,7 +6,10 @@ import os
 import sys
 import pwd
 import time
-import pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import subprocess
 from collections import defaultdict
 import numpy as np

--- a/python/desc/imsim/trim.py
+++ b/python/desc/imsim/trim.py
@@ -2,7 +2,10 @@
 Function to apply chip-centered acceptance cones on instance catalogs.
 """
 from collections import defaultdict
-import pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import numpy as np
 import lsst.sims.coordUtils
 from lsst.sims.utils import _angularSeparation

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -30,11 +30,16 @@ class PsfTestCase(unittest.TestCase):
         correctly.
         """
         for psf_name in ("DoubleGaussian", "Kolmogorov", "Atmospheric"):
+            if psf_name == 'Atmospheric':
+                screen_file = os.path.join(self.test_dir, "screens.pkl")
+            else:
+                screen_file = None
             psf = desc.imsim.make_psf(psf_name, self.obs_md, screen_scale=6.4)
             psf_file = os.path.join(self.test_dir, '{}.pkl'.format(psf_name))
-            desc.imsim.save_psf(psf, psf_file)
-            psf_retrieved = desc.imsim.load_psf(psf_file)
+            desc.imsim.save_psf(psf, psf_file, screen_file)
+            psf_retrieved = desc.imsim.load_psf(psf_file, screen_file)
             self.assertEqual(psf, psf_retrieved)
+
 
     def test_atm_psf_config(self):
         """


### PR DESCRIPTION
Addresses #234 .

Serializing AtmosphericScreens now requires dumping the shared memory and then separately pickling.  I added a command line argument to imsim.py to handle the shared memory piece when the PSF type is Atmospheric.  Depends on https://github.com/GalSim-developers/GalSim/pull/1057 