### PR TITLE
disable checkpoint summary by default

### DIFF
--- a/data/default_imsim_configs
+++ b/data/default_imsim_configs
@@ -43,6 +43,7 @@ catalog = default
 [checkpointing]
 nobj = 500
 cleanup = True
+do_summary = False
 
 [wl_params]
 gamma2_sign = -1

--- a/python/desc/imsim/ImageSimulator.py
+++ b/python/desc/imsim/ImageSimulator.py
@@ -253,8 +253,10 @@ class ImageSimulator:
         # Set the CHECKPOINT_SUMMARY variable so that the summary info
         # from the subprocesses can be persisted.
         global CHECKPOINT_SUMMARY
+        do_checkpoint_summary = self.config['checkpointing']['do_summary']
+
         if (self.file_id is not None and processes > 1 and
-            CHECKPOINT_SUMMARY is None):
+            CHECKPOINT_SUMMARY is None and do_checkpoint_summary):
             db_file = 'ckpt_{}_{}.sqlite3'.format(self.file_id, node_id)
             CHECKPOINT_SUMMARY = CheckpointSummary(db_file=db_file)
 

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -9,6 +9,7 @@ pip install coveralls
 pip install pylint
 git clone https://github.com/lsst/obs_lsst.git
 cd obs_lsst
+git checkout dc2/run2.1
 setup -r . -j
 
 # Build the obs_lsst package, but avoid the time consuming and lengthy


### PR DESCRIPTION
This change disables the generation of the sqlite3 db files that keep track of the numbers of objects written to the checkpoint files, while not affecting the writing of the checkpoint files themselves.  This change addresses the problems associated with using the `multiprocessing` module causing the jobs to hang at CC-IN2P3 and on the UK Grid even though all of the sensor-visits in the job have finished.  See discussion at https://lsstc.slack.com/archives/CJ50YVDD3/p1576260737024400 