### PR TITLE
update sdet_name when considering a different det_num

### DIFF
--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -31,8 +31,7 @@ class LSST_CCDBuilder(OutputBuilder):
         base['det_name'] = det_name
         if 'eval_variables' not in base:
             base['eval_variables'] = {}
-        if 'sdet_name' not in base['eval_variables']:
-            base['eval_variables']['sdet_name'] = det_name
+        base['eval_variables']['sdet_name'] = det_name
 
         base['exp_time'] = float(config.get('exp_time', 30))
 


### PR DESCRIPTION
Otherwise, `det_name` doesn't change when simulating multiple detectors.