### PR TITLE
Don't accept folding_threshold=0 if sky_level=0.

### DIFF
--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -76,7 +76,11 @@ class LSST_SiliconBuilder(StampBuilder):
             base['current_noise_image'] = base['current_image']
             noise_var = galsim.config.CalculateNoiseVariance(base)
             folding_threshold = noise_var/self.realized_flux
-            if folding_threshold >= self._ft_default:
+            if folding_threshold >= self._ft_default or folding_threshold == 0:
+                # a) Don't gratuitously raise folding_threshold above the normal default.
+                # b) If sky_level = 0, then folding_threshold=0.  This is bad (stepk=0 below),
+                #    but if the user is doing this to avoid sky noise, then they probably care about
+                #    other things than detailed large-scale behavior of very bright stars.
                 gsparams = None
             else:
                 # Every different folding threshold requires a new initialization of Kolmogorov,


### PR DESCRIPTION
Josh ran into a runtime error trying to do sky_level=0 with our default config.  This led to a calculation that folding_threshold=0 (since it tries to match the limiting surface brightness to the sky noise), which in turn caused stepk=0, and then a divide by zero error.

I think the right thing to do in this case is to reject that whole line of optimization and go back to the default gsparams, as we also do if the calculated folding threshold is more than the normal default.