### PR TITLE
Add an option to apply a specific SED in FlatBuilder

### DIFF
--- a/config/flat_with_sed.yaml
+++ b/config/flat_with_sed.yaml
@@ -51,7 +51,15 @@ image:
         treering_center: { type: TreeRingCenter, det_name: $det_name }
         treering_func: { type: TreeRingFunc, det_name: $det_name }
 
-    sed: "$galsim.SED(lambda x: 1, flux_type='flambda', wave_type='nm', _blue_limit=840, _red_limit=850)"
+    # If you provide an sed item, the code will take into account the absorption depth of
+    # the photons in the silicon according to their wavelength.
+    # This is significantly slower than not providing an sed, since it needs to run an extra
+    # (slow) step of generating a photon array from the sky image, converting them all into
+    # electrons at the right depth, and then accumulating them on the pixels.
+    # This is much slower than just computing the right amount of flux to add based on the
+    # current pixel area at each iteration.
+    # Note: when using an sed, you also need a bandpass.
+    sed: "$galsim.SED(galsim.LookupTable([930,940,950,960],[0,1,1,0]), 'nm', '1')"
 
     # For a custom function bandpass
     bandpass: "$galsim.Bandpass(lambda x: 1, wave_type='nm', blue_limit=700, red_limit=1200)"

--- a/config/flat_with_sed.yaml
+++ b/config/flat_with_sed.yaml
@@ -25,7 +25,12 @@ image:
     xsize: 4096
     ysize: 4096
 
-    counts_per_pixel: 800
+    # This is a ~typical count level for a flat.  But beware that with this value, this
+    # simulation run for just a single sensor takes more than a day to run on a typical
+    # machine.  Unless you really, really need to simulate the wavelength dependence of the
+    # sensor effects (such as brighter-fatter), you most likely want to use the regular
+    # flat.yaml configuration, which ignores the wavelength dependence.
+    counts_per_pixel: 80000
 
     wcs:
         type: Batoid

--- a/config/flat_with_sed.yaml
+++ b/config/flat_with_sed.yaml
@@ -1,0 +1,105 @@
+# This is an example of how to make a flat-field image with imsim.
+
+
+# Load the imsim modules.
+modules:
+    - imsim
+
+input:
+
+    tree_rings:
+        # This enables TreeRingCenter and TreeRungFunc, which are stored as a dict here based
+        # on the detector name, so the right value can be accessed for each object.
+        # This file lives in the imsim repo.
+        file_name: "tree_ring_parameters_2018-04-26.txt"
+        # Can limit the detectors to read in.  This is handy while debugging, since it takes
+        # a minute or so to read all 189 detectors (the default behavior).
+        only_dets: [R22_S11]
+
+
+image:
+    type: LSST_Flat
+
+    random_seed: 1234
+
+    xsize: 4096
+    ysize: 4096
+
+    counts_per_pixel: 800
+
+    wcs:
+        type: Batoid
+
+        # These are required, but the actual values don't matter for a flat field.
+        boresight:
+            type: RADec
+            ra: "0 degrees"
+            dec: "-30 degrees"
+        rotTelPos: "0 degrees"
+        obstime: "2024-01-01"
+
+        # These are relevant for a flat, so should make sure to get these right.
+        det_name: $det_name
+        band: y
+
+    noise:
+        type: Poisson
+
+    sensor:
+        type: Silicon
+        strength: 1.0
+        treering_center: { type: TreeRingCenter, det_name: $det_name }
+        treering_func: { type: TreeRingFunc, det_name: $det_name }
+
+    sed: "$galsim.SED(lambda x: 1, flux_type='flambda', wave_type='nm', _blue_limit=840, _red_limit=850)"
+
+    bandpass:
+        file_name: 'LSST_z.dat'
+        wave_type: 'nm'
+
+
+
+# This defines both the output files and some basic things about the overall exposure/fov.
+output:
+    type: LSST_CCD
+    nproc: 1    # Change this to work on multiple CCDs at once.
+    nfiles: 1   # Default is all 189 CCDs.  Set to 1 while testing.
+
+    camera: LsstCam
+
+    exp_time: 30
+
+    cosmic_ray_rate: 0.2
+
+    det_num:
+        type: Sequence
+        nitems: 189
+        first: 94  # Can set first to something if you want to do a specific sensor.
+
+    dir: flats
+    file_name:
+        type: FormattedStr
+        format : flat_eimage_%05d-%s-%s-det%03d.fits
+        items:
+            - 1  # When making multiple flats, probably should increment this for each file.
+            - "@image.wcs.band"
+            - "$det_name"   # A value stored in the dict by LSST_CCD
+            - "@output.det_num"
+
+    readout:
+        # Convert from e-image to realized amp images
+        readout_time: 3.
+        dark_current: 0.02
+        bias_level: 1000.
+        pcti: 1.e-6
+        scti: 1.e-6
+        filter: "@image.wcs.band"
+
+        file_name:
+            type: FormattedStr
+            format : flat_amp_%05d-%s-%s-det%03d.fits.fz
+            items:
+                - "@output.file_name.items.0"
+                - "@image.wcs.band"
+                - "$det_name"
+                - "@output.det_num"

--- a/config/flat_with_sed.yaml
+++ b/config/flat_with_sed.yaml
@@ -53,9 +53,13 @@ image:
 
     sed: "$galsim.SED(lambda x: 1, flux_type='flambda', wave_type='nm', _blue_limit=840, _red_limit=850)"
 
-    bandpass:
-        file_name: 'LSST_z.dat'
-        wave_type: 'nm'
+    # For a custom function bandpass
+    bandpass: "$galsim.Bandpass(lambda x: 1, wave_type='nm', blue_limit=700, red_limit=1200)"
+
+    # For a bandpass from a file
+    #bandpass:
+        #file_name: 'LSST_y.dat'
+        #wave_type: 'nm'
 
 
 

--- a/imsim/flat.py
+++ b/imsim/flat.py
@@ -52,7 +52,7 @@ class LSST_FlatBuilder(ImageBuilder):
         self.counts_per_pixel = params['counts_per_pixel']
         self.xsize = params['xsize']
         self.ysize = params['ysize']
-        self.buffer_size = params.get("buffer_size", 2)
+        self.buffer_size = params.get("buffer_size", 5)
         self.max_counts_per_iter = params.get("max_counts_per_iter", 1000)
         if 'sed' in config:
             self.sed = galsim.config.BuildSED(config, 'sed', base, logger=logger)[0]

--- a/imsim/flat.py
+++ b/imsim/flat.py
@@ -175,10 +175,7 @@ class LSST_FlatBuilder(ImageBuilder):
                         logger.info('mean level => %s',section.array.mean())
                     else:
                         temp_no_wcs = temp.view(scale=1.0)
-                        print('temp average = ',temp_no_wcs.array.mean())
                         photons = galsim.PhotonArray.makeFromImage(temp_no_wcs, rng=rng)
-                        print('sum photon flux = ',np.sum(photons.flux))
-                        print('sum photon flux / pixel = ',np.sum(photons.flux)/np.prod(temp_no_wcs.array.shape))
                         wavelength_sampler.applyTo(photons, rng=rng)
                         sensor.accumulate(photons, section)
                         logger.info('added %d photons: mean level => %s',

--- a/imsim/flat.py
+++ b/imsim/flat.py
@@ -210,7 +210,7 @@ class LSST_FlatBuilder(ImageBuilder):
                         wavelength_sampler.applyTo(photons, rng=rng)
                         # Accumulate the photons on the image
                         sensor.accumulate(photons, section, resume=(it>0))
-                        tot_nphot += len(photons)
+                        sec_nphot += len(photons)
                         logger.debug('added %d photons: mean level => %s',
                                      len(photons), section[sec_bounds].array.mean())
 

--- a/tests/test_flats.py
+++ b/tests/test_flats.py
@@ -21,7 +21,7 @@ class FlatTestCase(unittest.TestCase):
     def test_simple_flat(self):
         """Test of basic LSST_Flat functionality."""
 
-        counts_per_iter = 1_000
+        counts_per_iter = 10_000
         niter = 10
         tot_counts = counts_per_iter * niter
         config = {
@@ -105,7 +105,7 @@ class FlatTestCase(unittest.TestCase):
         print('cov10 01 11 = ', cov10, cov01, cov11)
         # These are now all significantly non-zero (and positive).
         assert cov10 > 1.e-2*tot_counts
-        assert cov01 > 5.e-3*tot_counts
+        assert cov01 > 3.e-3*tot_counts
         assert cov11 > 2.e-3*tot_counts
         # Also, 11 is the smallest, and there is more covariance in the y direction (10).
         assert cov10 > cov01 > cov11
@@ -113,7 +113,7 @@ class FlatTestCase(unittest.TestCase):
     def test_treerings_flat(self):
         """Test LSST_Flat with Silicon sensor and treerings."""
 
-        counts_per_iter = 1_000
+        counts_per_iter = 10_000
         niter = 10
         tot_counts = counts_per_iter * niter
         tree_amp = 0.26
@@ -167,7 +167,7 @@ class FlatTestCase(unittest.TestCase):
     def test_sed_flat(self):
         """Test LSST_Flat with an sed item"""
 
-        counts_per_iter = 1_000
+        counts_per_iter = 100
         niter = 5
         tot_counts = counts_per_iter * niter
         # Use an SED with a tight wavelength range in the z band

--- a/tests/test_flats.py
+++ b/tests/test_flats.py
@@ -170,7 +170,7 @@ class FlatTestCase(unittest.TestCase):
         counts_per_iter = 100
         niter = 5
         tot_counts = counts_per_iter * niter
-        # Use an SED with a tight wavelength range in the z band
+        # Use an SED with a tight wavelength range in the g band
         sed = galsim.SED(galsim.LookupTable([530,540,550,560],[0,1,1,0]), 'nm', '1')
         bandpass = galsim.Bandpass(lambda x: 1, wave_type='nm', blue_limit=400, red_limit=1200)
         config = {


### PR DESCRIPTION
@Alex-Broughton wanted to make flats with imsim for a narrow band of wavelengths to study the wavelength dependence of the brighter-fatter effect, but that wasn't possible with the current FlatBuilder.  In fact, it doesn't even try to do anything correct about the wavelengths for a full bandpass.

So this PR adds that capability, along with an example config called flat_with_sed.yaml.  If an sed item is given in the FlatBuilder field, then it will make photons drawn with that SED and run accumulate to get the right absorption depth for each photon.  It's quite a bit slower than the regular method we use, which implicitly converts everything right at the surface.  But it does the wavelength dependence correctly.