### PR TITLE
Fix test_psf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,6 @@ jobs:
               run:
                 pip install .
 
-            - name: Install main branch of GalSim
-              run: |
-                # need to make sure GalSim 2.4.0 is installed before
-                # the next imsim release:
-                pip install git+https://github.com/GalSim-developers/GalSim.git@main
-
             - name: Install test deps
               run:
                 conda install -y pytest nose

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,6 +1,6 @@
 # conda install --file conda_requirements should install all required dependencies of imSim.
 
 stackvana>=0.2021.30
-galsim>=2.3
+galsim>=2.4
 dust_extinction>=1.0
 palpy>=1.8.1

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -153,9 +153,10 @@ class AtmosphericPSF(object):
         else:
             if logger:
                 logger.warning(f"Using {nproc} processes to build the phase screens")
-            with ctx.Pool(nproc, initializer=galsim.phase_screens.initWorker,
-                          initargs=galsim.phase_screens.initWorkerArgs()) as pool:
-                self.atm.instantiate(pool=pool, kmax=kmax, check='phot')
+            with galsim.utilities.single_threaded():
+                with ctx.Pool(nproc, initializer=galsim.phase_screens.initWorker,
+                              initargs=galsim.phase_screens.initWorkerArgs()) as pool:
+                    self.atm.instantiate(pool=pool, kmax=kmax, check='phot')
 
         if logger:
             logger.info("Finished building atmosphere")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,4 @@ addopts = """
 --ignore=tests/test_skyModel.py
 --ignore=tests/test_get_stack_products.py
 --ignore=tests/test_imageSimulator.py
---ignore=tests/test_psf.py
 """


### PR DESCRIPTION
This PR fixes the error that was causing test_psf to hang recently.  It's due to a [bug in the gomp implementation of OpenMP](https://patchwork.ozlabs.org/project/gcc/patch/CAPJVwBkOF5GnrMr=4d1ehEKRGkY0tHzJzfXAYBguawu9y5wxXw@mail.gmail.com/) when used in forks.  I actually ran into it in the [GalSim unit tests too](https://github.com/GalSim-developers/GalSim/pull/1177/commits/0c3ed82f13a5e6321852c00bf30e68ee03287284), and I forgot that I would have to make the same change in imSim.

More references: [Here](http://galsim-developers.github.io/GalSim/_build/html/phase_psf.html#galsim.AtmosphericScreen) is the doc string where we officially recommend the specific pattern that I adopted in imsim.  And [here](https://galsim-developers.github.io/GalSim/_build/html/misc.html#galsim.utilities.single_threaded) is the description of single_threaded where we make the recommendation more generally.