### PR TITLE
ci: fix pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,18 +25,27 @@ jobs:
       - name: "Bypass jekyll on github pages"
         run: "touch public/.nojekyll"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: html-docs
           path: public/
   publish:
     needs: build
+
+    # Only manual publishing:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write     # to deploy to Pages
+      id-token: write  # to verify the deployment originates from an
+      # appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     runs-on: ubuntu-latest
     steps:
-      - name: Publish
-        uses: peaceiris/actions-gh-pages@v3
-        # Only manual publishing:
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: public/
+      - name: Publish to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Another try. This time, I was following https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site

and I now got:
```
Branch "doc" is not allowed to deploy to github-pages due to environment protection rules.
```
Already a good sign, but it also means that we have to merge to main in order to try this out (or change our protection rules, which I would not recommend).