### PR TITLE
Automatic imsim-env docker image publication CI

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,12 +1,21 @@
+# CI workflow to publish the imSim:latest docker image.
+#
+# Image is built upon the latest release lsst_dist image.
+# i.e., https://pipelines.lsst.io/install/docker.html
+#
+# Author: Stuart McAlpine (stuart.mcalpine@fysik.su.se)
+
 name: Publish imSim latest Docker image
 
 on:
+  # Can be triggered to run manually.
   workflow_dispatch:
 
-  pull_request:
+  # Runs automatically every Satuarday at 7pm.
+  schedule:
+    - cron: '0 19 * * 6'
 
-  push:
-
+# Login to dockerhub, build, and publish.
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,24 @@
+name: Publish imSim latest Docker image
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: lsstdesc/imsim-env:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,6 +1,9 @@
 name: Publish imSim latest Docker image
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -5,6 +5,8 @@ on:
 
   pull_request:
 
+  push:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -38,4 +38,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: lsstdesc/imsim-env:latest
-          build-args: BUILD_DATE=$NOW
+          build-args: BUILD_DATE=${{ env.NOW }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -20,6 +20,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -36,3 +38,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: lsstdesc/imsim-env:latest
+          build-args: BUILD_DATE=$NOW

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/LSSTDESC/imSim.git &&\
 RUN source /opt/lsst/software/stack/loadLSST.bash &&\
     setup lsst_distrib &&\
     pip install --upgrade galsim &&\
-    pip install dust_extinction palpy batoid &&\
+    pip install dust_extinction palpy batoid gitpython &&\
     pip install git+https://github.com/LSSTDESC/skyCatalogs.git@master &&\
     cd imSim && pip install -e . && cd .. &&\
     cd rubin_sim && pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # Start from the latest release LSST stack image.
-from lsstsqre/centos:7-stack-lsst_distrib-w_latest
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_latest
+
+# Information about image.
+ARG BUILD_DATE
+LABEL lsst-desc.imsim.maintainer="https://github.com/LSSTDESC/imSim"
+LABEL lsst-desc.imsim.description="A Docker image combining the LSST Science Pipelines software stack and imSim (and its dependencies)."
+LABEL lsst-desc.imsim.version="latest"
+LABEL lsst-desc.imsim.build_date=$BUILD_DATE
 
 # Clone imSim and rubin_sim repos.
 RUN git clone https://github.com/LSSTDESC/imSim.git &&\
@@ -17,10 +24,11 @@ RUN source /opt/lsst/software/stack/loadLSST.bash &&\
 # Download Rubin Sim data.
 RUN mkdir rubin_sim_data &&\
     curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz &&\
-    curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_aug_2021.tgz | tar -C rubin_sim_data -xz
+    curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_aug_2021.tgz | tar -C rubin_sim_data -xz &&\
+    curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz
 
 # Location of Rubin sim data (downloaded in step above).
 ENV RUBIN_SIM_DATA_DIR /opt/lsst/software/stack/rubin_sim_data
 
-# SED library at NERSC.
-ENV SIMS_SED_LIBRARY_DIR /global/cfs/cdirs/descssim/imSim/lsst/data/sims_sed_library
+# SED library (downloaded in step above).
+ENV SIMS_SED_LIBRARY_DIR /opt/lsst/software/stack/rubin_sim_data/sims_sed_library

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Start from the latest release LSST stack image.
+from lsstsqre/centos:7-stack-lsst_distrib-w_latest
+
+# Clone imSim and rubin_sim repos.
+RUN git clone https://github.com/LSSTDESC/imSim.git &&\
+    git clone https://github.com/lsst/rubin_sim.git
+
+# Install imSim, rubin_sim, and dependencies.
+RUN source /opt/lsst/software/stack/loadLSST.bash &&\
+    setup lsst_distrib &&\
+    pip install --upgrade galsim &&\
+    pip install dust_extinction palpy batoid &&\
+    pip install git+https://github.com/LSSTDESC/skyCatalogs.git@master &&\
+    cd imSim && pip install -e . && cd .. &&\
+    cd rubin_sim && pip install -e .
+
+# Download Rubin Sim data.
+RUN mkdir rubin_sim_data &&\
+    curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz &&\
+    curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_aug_2021.tgz | tar -C rubin_sim_data -xz
+
+# Location of Rubin sim data (downloaded in step above).
+ENV RUBIN_SIM_DATA_DIR /opt/lsst/software/stack/rubin_sim_data
+
+# SED library at NERSC.
+ENV SIMS_SED_LIBRARY_DIR /global/cfs/cdirs/descssim/imSim/lsst/data/sims_sed_library

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN source /opt/lsst/software/stack/loadLSST.bash &&\
     cd rubin_sim && pip install -e .
 
 # Download Rubin Sim data.
-RUN mkdir rubin_sim_data &&\
+RUN mkdir -p rubin_sim_data/sims_sed_library && \
     curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz &&\
     curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_aug_2021.tgz | tar -C rubin_sim_data -xz &&\
     curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz


### PR DESCRIPTION
Includes a Docker file and CI workflow to automatically publish a "latest" imsim-env image to the lsstdesc DockerHub repo.

The image is built with the latest version of the LSST Science Pipelines stack, imSim, and imSim's dependencies.

In the future/next step, I think we should also have a docker image associated with each release of imSim, to accompany the latest version.