### PR TITLE
instcat MJD-OBS bug

### DIFF
--- a/imsim/opsim_meta.py
+++ b/imsim/opsim_meta.py
@@ -188,13 +188,15 @@ class OpsimMetaDict(object):
         self.logger.debug("Bandpass = %s",self.meta['band'])
         self.logger.debug("HA = %s",self.meta['HA'])
 
+        self.set_defaults()
+
         # Use the opsim db names for these quantities.
         self.meta['fieldRA'] = self.meta['rightascension']
         self.meta['fieldDec'] = self.meta['declination']
         self.meta['rotTelPos'] = self.meta['rottelpos']
         self.meta['rotSkyPos'] = self.meta['rotskypos']
         self.meta['observationId'] = self.meta['obshistid']
-        self.set_defaults()
+        self.meta['observationStartMJD'] = self.meta['mjd'] - self.meta['exptime']/2./86400.
 
     def set_defaults(self):
         # Set some default values if these aren't present in input file.

--- a/tests/test_header_keywords.py
+++ b/tests/test_header_keywords.py
@@ -1,0 +1,61 @@
+import os
+import glob
+import shutil
+import sys
+from pathlib import Path
+import logging
+from astropy.io import fits
+import numpy as np
+import galsim
+
+
+def run_imsim(camera):
+    imsim_dir = os.path.dirname(os.path.abspath(str(Path(__file__).parent)))
+    template = os.path.join(imsim_dir, 'config', 'imsim-config.yaml')
+    instcat_file = os.path.join(imsim_dir, 'tests', 'data',
+                                'instcat_object_positions_test.txt')
+
+    logger = logging.getLogger('test_header_keywords')
+    if len(logger.handlers) == 0:
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+    logger.setLevel(logging.CRITICAL)  # silence the log messages
+
+    only_dets = ['R22_S11']
+
+    config = {'template': template,
+              'input.instance_catalog.file_name': instcat_file,
+              'input.opsim_meta_dict.file_name': instcat_file,
+              'input.tree_rings.only_dets': only_dets,
+              'input.atm_psf': '',
+              'image.sky_level': 0,
+              'image.random_seed': 42,
+              'image.sensor': '',
+              'stamp.fft_sb_thresh': '1e5',
+              'stamp.size': 48,
+              'psf.items': '',
+              'psf.type': 'Gaussian',
+              'psf.fwhm': 0.7,
+              'output.camera': camera,
+              'output.cosmic_ray_rate': 0,
+              'output.only_dets': only_dets,
+              'output.det_num.first': 0,
+              'output.nfiles': 1,
+              'output.readout': '',
+              'output.dir': 'fits_header_test',
+              'output.truth': ''}
+
+    galsim.config.Process(config, logger=logger)
+
+
+def test_header_keywords():
+    run_imsim('LsstCam')
+    fits_dir = 'fits_header_test'
+    eimage_file = glob.glob(os.path.join(fits_dir, 'eimage*.fits'))[0]
+    with fits.open(eimage_file) as hdus:
+        mjd = hdus[0].header['MJD']
+        exptime = hdus[0].header['EXPTIME']
+        mjd_obs = mjd + exptime/2./86400.
+        np.testing.assert_approx_equal(hdus[0].header['MJD-OBS'], mjd_obs,
+                                       significant=7)
+    os.remove(os.path.join(eimage_file))
+    os.removedirs(os.path.dirname(eimage_file))

--- a/tests/test_header_keywords.py
+++ b/tests/test_header_keywords.py
@@ -1,6 +1,5 @@
 import os
 import glob
-import shutil
 import sys
 from pathlib import Path
 import logging
@@ -11,6 +10,8 @@ import galsim
 
 def run_imsim(camera):
     imsim_dir = os.path.dirname(os.path.abspath(str(Path(__file__).parent)))
+    os.environ['SIMS_SED_LIBRARY_DIR'] \
+        = os.path.join(imsim_dir, 'tests', 'data', 'test_sed_library')
     template = os.path.join(imsim_dir, 'config', 'imsim-config.yaml')
     instcat_file = os.path.join(imsim_dir, 'tests', 'data',
                                 'instcat_object_positions_test.txt')

--- a/tests/test_object_positions.py
+++ b/tests/test_object_positions.py
@@ -10,6 +10,8 @@ import galsim
 
 def run_imsim(camera):
     imsim_dir = os.path.dirname(os.path.abspath(str(Path(__file__).parent)))
+    os.environ['SIMS_SED_LIBRARY_DIR'] \
+        = os.path.join(imsim_dir, 'tests', 'data', 'test_sed_library')
     template = os.path.join(imsim_dir, 'config', 'imsim-config.yaml')
     instcat_file = os.path.join(imsim_dir, 'tests', 'data',
                                 'instcat_object_positions_test.txt')
@@ -17,7 +19,7 @@ def run_imsim(camera):
     logger = logging.getLogger('test_object_positions')
     if len(logger.handlers) == 0:
         logger.addHandler(logging.StreamHandler(sys.stdout))
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.CRITICAL)
 
     only_dets = ['R22_S11', 'R01_S00', 'R42_S21', 'R34_S22', 'R03_S02']
 


### PR DESCRIPTION
The `MJD-OBS` header keyword was not being set correctly for the `eimage*` and `amp *` output files when using an instance catalog as the source of the metadata for the observation.   This resulted in files with observing dates outside the validity range of the DC2 calibration data, which in turn caused failures when analyzing with the LSST code.