### PR TITLE
set maxN in drawImage for FFT rendering to limit memory usage

### DIFF
--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -475,6 +475,12 @@ class LSST_SiliconBuilder(StampBuilder):
 
         wcs = base['wcs']
 
+        # Set limit on the size of photons batches to consider when
+        # calling gsobject.drawImage.
+        maxN = int(1e6)
+        if 'maxN' in config:
+            maxN = galsim.config.ParseValue(config, 'maxN', base, int)[0]
+
         if method == 'fft':
             if not faint and 'fft_photon_ops' in config:
                 photon_ops = galsim.config.BuildPhotonOps(config, 'fft_photon_ops', base, logger)
@@ -494,7 +500,7 @@ class LSST_SiliconBuilder(StampBuilder):
                                rng=self.rng,
                                sensor=galsim.Sensor(),
                                n_subsample=1,
-                               maxN=int(1e6)
+                               maxN=maxN
                                )
             except galsim.errors.GalSimFFTSizeError as e:
                 # I think this shouldn't happen with the updates I made to how the image size
@@ -534,7 +540,7 @@ class LSST_SiliconBuilder(StampBuilder):
                            method='phot',
                            offset=offset,
                            rng=self.rng,
-                           maxN=int(1e6),
+                           maxN=maxN,
                            n_photons=self.realized_flux,
                            image=image,
                            wcs=wcs,

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -493,7 +493,8 @@ class LSST_SiliconBuilder(StampBuilder):
                                photon_ops=photon_ops,
                                rng=self.rng,
                                sensor=galsim.Sensor(),
-                               n_subsample=1
+                               n_subsample=1,
+                               maxN=int(1e6)
                                )
             except galsim.errors.GalSimFFTSizeError as e:
                 # I think this shouldn't happen with the updates I made to how the image size

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -79,13 +79,13 @@ def test_lsst_silicon_builder_passes_correct_photon_ops_to_drawImage() -> None:
     logger = mock.Mock(info=mock.Mock())
     built_photon_ops = mock.Mock()
     expected_phot_args = {
-        "maxN": int(1e6),
+        "maxN": mock.ANY,
         "n_photons": mock.ANY,
         "add_to_image": True,
         "poisson_flux": False,
         "image": image,
     }
-    expected_fft_args = {"n_subsample": 1, "image": image_copy}
+    expected_fft_args = {"n_subsample": 1, "image": image_copy, "maxN": mock.ANY}
     for method, expected_specific_args in (
         ("phot", expected_phot_args),
         ("fft", expected_fft_args),
@@ -138,13 +138,13 @@ def test_stamp_builder_works_without_photon_ops_or_faint() -> None:
     offset = mock.Mock()
     logger = mock.Mock(info=mock.Mock())
     expected_phot_args = {
-        "maxN": int(1e6),
+        "maxN": mock.ANY,
         "n_photons": mock.ANY,
         "add_to_image": True,
         "poisson_flux": False,
         "image": image,
     }
-    expected_fft_args = {"n_subsample": 1, "image": image_copy}
+    expected_fft_args = {"n_subsample": 1, "image": image_copy, "maxN": mock.ANY}
     for method, expected_specific_args in (
         ("phot", expected_phot_args),
         ("fft", expected_fft_args),


### PR DESCRIPTION
With `fft_photon_ops` enabled, the memory can increase to tens of GB for bright stars without `maxN` set.  Using `maxN=int(1e6)` limits the memory jumps to < 0.5 GB.