### PR TITLE
Use GalSim 2.4.7 fix for atmospheric screen memory sharing.

### DIFF
--- a/etc/standalone_conda_requirements.txt
+++ b/etc/standalone_conda_requirements.txt
@@ -1,6 +1,6 @@
 # conda install --file etc/standalone_conda_requirements should install all required dependencies of imSim including a conda based version of the Rubin pipelines.
 
 stackvana>=0.2021.30
-galsim>=2.4
+galsim>=2.4.7
 dust_extinction>=1.0
 palpy>=1.8.1

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -298,6 +298,13 @@ class AtmLoader(InputLoader):
           exposures (rather than just multiple CCDs for a single exposure), we'll need to
           reconsider this implementation.
     """
+    def __init__(self):
+        # Override some defaults in the base init.
+        super().__init__(init_func=AtmosphericPSF,
+                         takes_logger=True, use_proxy=False,
+                         worker_init=galsim.phase_screens.initWorker,
+                         worker_initargs=galsim.phase_screens.initWorkerArgs)
+
     def getKwargs(self, config, base, logger):
         logger.debug("Get kwargs for AtmosphericPSF")
 
@@ -340,12 +347,7 @@ class AtmLoader(InputLoader):
         kwargs['logger'] = logger
 
         # safe=True means this will be used for the whole run.
-        #safe = True
-        # TODO: However, this isn't working yet, since the multiple processes aren't getting the
-        # GSScreenShare dict updated properly.  For now, we rely on the base process making the
-        # atmosphere if necessary and saving it to save_file.  Then other processes will
-        # load it in.  This happens if safe=False.
-        safe=False
+        safe = True
 
         return kwargs, safe
 
@@ -461,7 +463,7 @@ def BuildKolmogorovPSF(config, base, ignore, gsparams, logger):
 
     return psf, safe
 
-RegisterInputType('atm_psf', AtmLoader(AtmosphericPSF, takes_logger=True))
+RegisterInputType('atm_psf', AtmLoader())
 RegisterObjectType('AtmosphericPSF', BuildAtmosphericPSF, input_type='atm_psf')
 RegisterObjectType('DoubleGaussianPSF', BuildDoubleGaussianPSF)
 RegisterObjectType('KolmogorovPSF', BuildKolmogorovPSF)

--- a/imsim/flat.py
+++ b/imsim/flat.py
@@ -226,7 +226,7 @@ class LSST_FlatBuilder(ImageBuilder):
             logger.info('Accumulated %s photons in total. Total time = %s min',
                         tot_nphot, (t2-t0)/60.)
 
-    def getNObj(self, config, base, image_num, logger=None):
+    def getNObj(self, config, base, image_num, logger=None, approx=False):
         """Get the number of objects that will be built for this image.
 
         There are no objects drawn in a flat, so this returns 0.
@@ -236,6 +236,7 @@ class LSST_FlatBuilder(ImageBuilder):
             base:       The base configuration dict.
             image_num:  The current image number.
             logger:     If given, a logger object to log progress.
+            approx:     Ignored
 
         Returns:
             the number of objects (=0)

--- a/imsim/opsim_meta.py
+++ b/imsim/opsim_meta.py
@@ -10,41 +10,6 @@ import galsim
 from .instcat import fopen
 
 
-# I don't really understand why the InputProxy implementation in GalSim doesn't work on some of
-# our imsim input classes, even though it works on all the regular GalSim input classes.
-# But changing the implementation a bit here does seem to work.
-# For now, I'm just monkey-patching it here, but if this continues to work, I'll put this version
-# in GalSim and release an update.
-# TODO: Once we can depend on Galsim >= 2.4.7, remove this.
-import types
-from multiprocessing.managers import NamespaceProxy
-import galsim.config.input
-
-def InputProxy(target):
-    """ Create a derived NamespaceProxy class for `target`. """
-
-    # This bit follows what multiprocessing.managers.MakeProxy normally does.
-    dic = {}
-    public_methods = [m for m in dir(target) if m[0] != '_']
-    for meth in public_methods:
-        exec('''def %s(self, /, *args, **kwds):
-                    return self._callmethod(%r, args, kwds)
-             '''%(meth,meth), dic)
-
-    # NamespaceProxy starts with __getattribute__ defined, so subclass from that rather than
-    # BaseProxy, as MakeProxy normally does.
-    proxy_name = target.__name__ + "_Proxy"
-    ProxyType = type(proxy_name, (NamespaceProxy,), dic)
-
-    # Expose all the public methods and also __getattribute__.
-    ProxyType._exposed_ = tuple(public_methods + ['__getattribute__'])
-
-    return ProxyType
-
-galsim.config.input.InputProxy = InputProxy
-
-
-
 def get_opsim_md(config, base):
     """
     If we don't have an OpsimMeta, then skip some header items.


### PR DESCRIPTION
This PR updates the AtmosphericPSF input type to use the new features in GalSim 2.4.7 that let it share memory properly.  Basically, it tells GalSim not to use the proxies, but instead start the workers with the initialization functions that copy over pointers to the global dict where the screens live.

I also got rid of the mokey patch for the InputProxy class, since the correct version of that is now in GalSim.