### PR TITLE
Add FEA perturbations to telescope loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
               run: |
                 # We need to get batoid onto conda, but for now, this is a separate step.
                 pip install batoid
+                pip install batoid_rubin
                 pip install skyCatalogs==1.2.0
                 conda info
                 conda list

--- a/tests/test_telescope_loader.py
+++ b/tests/test_telescope_loader.py
@@ -344,3 +344,270 @@ def test_config_zernike_perturbation():
             'telescope'
         ).get('base')
         assert perturbed == ref
+
+
+def test_config_fea():
+    """Test that we can use batoid_rubin package to add FEA perturbations.
+    """
+
+    # It's difficult to directly add a bending mode or printthrough to a
+    # surface figure, but we can at least test that we can manipulate rigid
+    # body degrees-of-freedom either directly or through the FEA interface.
+
+    # First standard degree of freedom is M2 -dz in microns
+    telescope = imsim.load_telescope("LSST_r.yaml")
+    ref = (telescope
+        .withGloballyShiftedOptic(
+            'M2',
+            [0, 0, 1e-6]
+        )
+    )
+
+    perturb_config = textwrap.dedent(
+        f"""
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    aos_dof:
+                        dof: '$[-1.0]+[0.0]*49'
+        """
+    )
+
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')
+    assert ref == perturbed
+
+    # Next is M2 -dx and +dy
+    telescope = imsim.load_telescope("LSST_r.yaml")
+    ref = (telescope
+        .withGloballyShiftedOptic(
+            'M2',
+            [2e-6, 3e-6, 0]
+        )
+    )
+    dof = [0.0, -2.0, +3.0] + [0.0]*47
+    dofstr = ",".join(str(s) for s in dof)
+
+    perturb_config = textwrap.dedent(
+        f"""
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    aos_dof:
+                        dof: [{dofstr}]
+        """
+    )
+
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')
+    assert ref == perturbed
+
+    # Next is M2 -Rx and Ry in arcsec
+    telescope = imsim.load_telescope("LSST_r.yaml")
+    ref = (telescope
+        .withLocallyRotatedOptic(
+            'M2',
+            batoid.RotX(np.deg2rad(2./3600))@batoid.RotY(np.deg2rad(3./3600))
+        )
+    )
+    dof = [0.0]*3 + [-2.0, 3.0] + [0.0]*45
+    dofstr = ",".join(str(s) for s in dof)
+
+    perturb_config = textwrap.dedent(
+        f"""
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    aos_dof:
+                        dof: [{dofstr}]
+        """
+    )
+
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')
+    # Just get close for this one since it depends slightly on order of applying
+    # X,Y rotations.
+    np.testing.assert_allclose(
+        ref['M2'].coordSys.rot,
+        perturbed['M2'].coordSys.rot,
+        atol=1e-12, rtol=0
+    )
+
+    # Repeat of above for Camera shifts and tilts.
+    telescope = imsim.load_telescope("LSST_r.yaml")
+    ref = (telescope
+        .withGloballyShiftedOptic(
+            'LSSTCamera',
+            [0, 0, 1e-6]
+        )
+    )
+    dof = [0.0]*5+[-1.0]+[0.0]*44
+    dofstr = ",".join(str(s) for s in dof)
+
+    perturb_config = textwrap.dedent(
+        f"""
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    aos_dof:
+                        dof: [{dofstr}]
+        """
+    )
+
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')
+    assert ref == perturbed
+
+    # Next is camera -dx and +dy
+    telescope = imsim.load_telescope("LSST_r.yaml")
+    ref = (telescope
+        .withGloballyShiftedOptic(
+            'LSSTCamera',
+            [2e-6, 3e-6, 0]
+        )
+    )
+    dof = [0.0]*5 + [0.0, -2.0, +3.0] + [0.0]*42
+    dofstr = ",".join(str(s) for s in dof)
+
+    perturb_config = textwrap.dedent(
+        f"""
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    aos_dof:
+                        dof: [{dofstr}]
+        """
+    )
+
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')
+    assert ref == perturbed
+
+    # Next is camera -Rx and Ry in arcsec
+    telescope = imsim.load_telescope("LSST_r.yaml")
+    ref = (telescope
+        .withLocallyRotatedOptic(
+            'LSSTCamera',
+            batoid.RotX(np.deg2rad(2./3600))@batoid.RotY(np.deg2rad(3./3600))
+        )
+    )
+    dof = [0.0]*8 + [-2.0, 3.0] + [0.0]*40
+    dofstr = ",".join(str(s) for s in dof)
+
+    perturb_config = textwrap.dedent(
+        f"""
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    aos_dof:
+                        dof: [{dofstr}]
+        """
+    )
+
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')
+    # Just get close for this one since it depends slightly on order of applying
+    # X,Y rotations.
+    np.testing.assert_allclose(
+        ref['LSSTCamera'].coordSys.rot,
+        perturbed['LSSTCamera'].coordSys.rot,
+        atol=1e-12, rtol=0
+    )
+    # Sub items should also agree in orientation and position
+    np.testing.assert_allclose(
+        ref['Filter'].coordSys.origin,
+        perturbed['Filter'].coordSys.origin,
+        atol=1e-12, rtol=0
+    )
+    np.testing.assert_allclose(
+        ref['Filter'].coordSys.rot,
+        perturbed['Filter'].coordSys.rot,
+        atol=1e-12, rtol=0
+    )
+
+
+    # Finally, just make sure we can construct a telescope with (at least most)
+    # of the FEA perturbations turned on.
+    perturb_config = textwrap.dedent(
+        f"""
+        eval_variables:
+            azenith: &zenith 30 deg
+            arot: &rot 15 deg
+        input:
+            telescope:
+                file_name: LSST_r.yaml
+                fea:
+                    m1m3_gravity:
+                        zenith_angle: *zenith
+                    m1m3_temperature:
+                        m1m3_TBulk: 0.0
+                        m1m3_TxGrad: 0.1
+                        m1m3_TyGrad: 0.1
+                        m1m3_TzGrad: 0.1
+                        m1m3_TrGrad: 0.1
+                    m1m3_lut:
+                        zenith_angle: *zenith
+                        error: 0.0
+                        seed: 1
+                    m2_gravity:
+                        zenith_angle: *zenith
+                    m2_temperature:
+                        m2_TzGrad: 0.1
+                        m2_TrGrad: 0.1
+                    camera_gravity:
+                        zenith_angle: *zenith
+                        rotation_angle: *rot
+                    camera_temperature:
+                        camera_TBulk: 0.1
+        """
+    )
+    config = yaml.safe_load(perturb_config)
+    galsim.config.ProcessInput(config)
+    perturbed = galsim.config.GetInputObj(
+        'telescope',
+        config['input']['telescope'],
+        config,
+        'telescope'
+    ).get('base')


### PR DESCRIPTION
Adds finite element perturbations to telescope loader.  These include things like mirror figure flexure due to gravity, bulk temperature, and temperature gradients.  Relies on the `batoid_rubin` package.

Note the implementation here is dependent on a particular structure for methods and argument names within the batoid_rubin package.  While this may be a bit of a code-smell, I don't think it will be a problem in practice, and is an expedient way to get this FEA functionality into ImSim.  It also offloads future changes in the FEA model to batoid_rubin.

With this update, I think all of the functionality for generating donuts available using phosim/ts_phosim will now be available in ImSim (plus we'll get the camera rotator correct!).