### PR TITLE
Change docker permissions to work with shifter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN source /opt/lsst/software/stack/loadLSST.bash &&\
     setup lsst_distrib &&\
     mamba install -y --file imSim/etc/docker_conda_requirements.txt &&\
     python3 -m pip install batoid skyCatalogs==1.2.0 gitpython &&\
-    python3 -m pip install -e rubin_sim/ &&\
-    python3 -m pip install -e imSim/
+    python3 -m pip install rubin_sim/ &&\
+    python3 -m pip install imSim/
 
 WORKDIR /opt/lsst/software/stack
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[<img src="https://img.shields.io/badge/dockerhub-imSim image-orange.svg?logo=Docker">](https://hub.docker.com/r/lsstdesc/imsim-env)
 [![Build Status](https://travis-ci.org/LSSTDESC/imSim.svg?branch=main)](https://travis-ci.org/LSSTDESC/imSim)
 [![Coverage Status](https://coveralls.io/repos/github/LSSTDESC/imSim/badge.svg?branch=main)](https://coveralls.io/github/LSSTDESC/imSim?branch=main)
 


### PR DESCRIPTION
Shifter cant run as root, so cant have imSim as editable install in docker file, reverted it back to static.

Also added a badge on the readme pointing to the built docker image at dockerhub.