### PR TITLE
add degrees to latitude config entry so that it's read in as an Angle

### DIFF
--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -223,7 +223,7 @@ stamp:
             R_inner: 2.55  # M1 inner diameter is 2.558, but we need a bit of slack for off-axis rays
         -
             type: RubinDiffraction
-            latitude: -30.24463
+            latitude: -30.24463 degrees
 
     photon_ops:
         -


### PR DESCRIPTION
Without specifying as `degrees`, this is causing errors like this:
```
  File "/global/u1/j/jchiang8/dev/imSim/imsim/photon_ops.py", line 403, in deserialize_rubin_diffraction
    kwargs = config_kwargs(config, base, RubinDiffraction)
  File "/global/u1/j/jchiang8/dev/imSim/imsim/photon_ops.py", line 349, in config_kwargs
    kwargs, _safe = GetAllParams(config, base, req, opt, single)
  File "/global/homes/j/jchiang8/.local/lib/python3.10/site-packages/galsim/config/value.py", line 415, in GetAllParams
    val, safe1 = ParseValue(config, key, base, value_type)
  File "/global/homes/j/jchiang8/.local/lib/python3.10/site-packages/galsim/config/value.py", line 195, in ParseValue
    val = _GetAngleValue(param)
  File "/global/homes/j/jchiang8/.local/lib/python3.10/site-packages/galsim/config/value.py", line 442, in _GetAngleValue
    raise GalSimConfigError("Unable to parse %s as an Angle. Caught %s"%(param,e))
galsim.errors.GalSimConfigError: Unable to parse -30.24463 as an Angle. Caught 'float' object has no attribute 'rsplit'
```