### PR TITLE
check if a logger has been provided

### DIFF
--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -213,7 +213,8 @@ class TelescopeLoader(InputLoader):
         ccd_orientation = camera[det_name].getOrientation()
         if hasattr(ccd_orientation, 'getHeight'):
             z_offset = ccd_orientation.getHeight()*1.0e-3  # Convert to meters.
-            logger.info("Setting CCD z-offset to %.2e m", z_offset)
+            if logger is not None:
+                logger.info("Setting CCD z-offset to %.2e m", z_offset)
         else:
             z_offset = 0
 

--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -1,5 +1,6 @@
 from galsim.config import (
-    InputLoader, RegisterInputType, GetAllParams, get_cls_params, ParseValue
+    InputLoader, RegisterInputType, GetAllParams, get_cls_params, ParseValue,
+    LoggerWrapper
 )
 from galsim import Angle
 import batoid
@@ -207,14 +208,14 @@ class TelescopeLoader(InputLoader):
 
     def setupImage(self, input_obj, config, base, logger=None):
         """Set up the telescope for the current image."""
+        logger = LoggerWrapper(logger)
         camera = get_camera(base['output']['camera'])
         det_name = base['det_name']
 
         ccd_orientation = camera[det_name].getOrientation()
         if hasattr(ccd_orientation, 'getHeight'):
             z_offset = ccd_orientation.getHeight()*1.0e-3  # Convert to meters.
-            if logger is not None:
-                logger.info("Setting CCD z-offset to %.2e m", z_offset)
+            logger.info("Setting CCD z-offset to %.2e m", z_offset)
         else:
             z_offset = 0
 


### PR DESCRIPTION
This addresses #331.  We're not seeing the error in this repo's CI run because we are still using lsst_distrib `w_2022_21`, e.g., see [this line](https://github.com/LSSTDESC/imSim/actions/runs/4601408001/jobs/8129222734#step:9:11) from the most recent GHA tests, and the code to add the `getHeight` attribute to the CCD orientation object was added to lsst_distrib much later than `w_2022_21`.