### PR TITLE
#321 Fix telescope input class to work correctly in multiprocessing

### DIFF
--- a/imsim/batoid_wcs.py
+++ b/imsim/batoid_wcs.py
@@ -496,7 +496,7 @@ class BatoidWCSBuilder(WCSBuilder):
             self._camera = get_camera(self._camera_name)
         order = kwargs.pop('order', 3)
         det_name = kwargs.pop('det_name')
-        kwargs['telescope'] = GetInputObj('telescope', config, base, 'telescope')['base']
+        kwargs['telescope'] = GetInputObj('telescope', config, base, 'telescope').get('base')
         factory = self.makeWCSFactory(**kwargs)
         det = self.camera[det_name]
         logger.info("Building Batoid WCS for %s and %s", det_name,

--- a/imsim/photon_ops.py
+++ b/imsim/photon_ops.py
@@ -353,7 +353,7 @@ def config_kwargs(config, base, cls):
 @photon_op_type("RubinOptics", input_type="telescope")
 def deserialize_rubin_optics(config, base, _logger):
     kwargs = config_kwargs(config, base, RubinOptics)
-    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope")["det"]
+    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope").get("det")
 
     return RubinOptics(
         telescope=telescope,
@@ -370,7 +370,7 @@ def deserialize_rubin_optics(config, base, _logger):
 def deserialize_rubin_diffraction_optics(config, base, _logger):
     kwargs = config_kwargs(config, base, RubinDiffractionOptics)
     opsim_meta = get_opsim_meta(config, base)
-    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope")["det"]
+    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope").get("det")
     rubin_diffraction = RubinDiffraction(
         telescope=telescope,
         latitude=kwargs.pop("latitude", RUBIN_LOC.lat.rad),
@@ -402,7 +402,7 @@ def get_camera_cached(camera_name: str):
 def deserialize_rubin_diffraction(config, base, _logger):
     kwargs = config_kwargs(config, base, RubinDiffraction)
     opsim_meta = get_opsim_meta(config, base)
-    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope")["det"]
+    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope").get("det")
 
     return RubinDiffraction(
         telescope=telescope,

--- a/tests/test_telescope_loader.py
+++ b/tests/test_telescope_loader.py
@@ -65,7 +65,7 @@ def test_config_shift():
             config['input']['telescope'],
             config,
             'telescope'
-        )['base']
+        ).get('base')
         assert shifted == shifted_ref
 
     # Test out exceptions
@@ -155,7 +155,7 @@ def test_config_rot():
             config['input']['telescope'],
             config,
             'telescope'
-        )['base']
+        ).get('base')
         assert rotated == rotated_ref
 
     # Check that we can rotate the camera using rotTelPos
@@ -173,7 +173,7 @@ def test_config_rot():
         config['input']['telescope'],
         config,
         'telescope'
-    )['base']
+    ).get('base')
     assert (
         rotated ==
         telescope.withLocallyRotatedOptic(
@@ -284,7 +284,7 @@ def test_config_zernike_perturbation():
             config['input']['telescope'],
             config,
             'telescope'
-        )['base']
+        ).get('base')
         assert perturbed == ref
 
     # Test that we can set more than one Zernike at a time,
@@ -342,5 +342,5 @@ def test_config_zernike_perturbation():
             config['input']['telescope'],
             config,
             'telescope'
-        )['base']
+        ).get('base')
         assert perturbed == ref


### PR DESCRIPTION
The telescope proxy was broken for use in multiprocessing as described by @jchiang87 in #321.

The problem is that the proxies we use for multiprocessing communication of input data can only call methods of the underlying object, not access attributes or call hidden (i.e. leading underscore) method like `__getitem__`.

So I changed our telescope dict to a bona fide class, called Telescopes, and forced the access to use `.get` rather than `.__getitem__` (aka `[]`).