### PR TITLE
Fix telescope multiprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ ENV/
 bin/
 .sconf_temp
 .sconsign.dblite
+
+# Test outputs that don't always get cleaned up.
+fits_LsstCam/
+fits_LsstCamImSim/
+output/

--- a/imsim/batoid_wcs.py
+++ b/imsim/batoid_wcs.py
@@ -73,8 +73,7 @@ class BatoidWCSFactory:
         camera,
         temperature,
         pressure,
-        H2O_pressure,
-        logger=None
+        H2O_pressure
     ):
         self.boresight = boresight
         self.obstime = obstime
@@ -103,8 +102,6 @@ class BatoidWCSFactory:
         es = 6.11 * np.exp(17.27 * self.tc / (237.3 + self.tc))  # mbar
         self.rh = self.H2O_pressure/es  # relative humidity
         self.wl = self.wavelength * 1e-3  # nm -> micron
-
-        self.logger = logger
 
     def _ICRF_to_observed(self, rc, dc, all=False):
         """
@@ -509,7 +506,6 @@ class BatoidWCSBuilder(WCSBuilder):
         order = kwargs.pop('order', 3)
         det_name = kwargs.pop('det_name')
         kwargs['telescope'] = GetInputObj('telescope', config, base, 'telescope').fiducial
-        kwargs['logger'] = logger
         factory = self.makeWCSFactory(**kwargs)
         det = self.camera[det_name]
         logger.info("Building Batoid WCS for %s and %s on pid=%d", det_name,
@@ -522,7 +518,7 @@ class BatoidWCSBuilder(WCSBuilder):
         self, boresight, obstime, telescope,
         camera='LsstCam',
         temperature=None, pressure=None, H2O_pressure=None,
-        wavelength=None, bandpass=None, logger=None
+        wavelength=None, bandpass=None
     ):
         """Make the WCS factory given the parameters explicitly rather than via a config dict.
 
@@ -589,7 +585,7 @@ class BatoidWCSBuilder(WCSBuilder):
         # Finally, build the WCS.
         return BatoidWCSFactory(
             boresight, obstime, telescope, wavelength, self.camera, temperature,
-            pressure, H2O_pressure, logger
+            pressure, H2O_pressure
         )
 
 

--- a/imsim/photon_ops.py
+++ b/imsim/photon_ops.py
@@ -63,16 +63,6 @@ class RubinOptics(PhotonOp):
         self.icrf_to_field = icrf_to_field
         self.logger = logger
 
-        if self.logger:
-            import os
-            self.logger.info(
-                "__init__ id(telescope)=%d detector.name=%s z-origin=%f pid=%d",
-                id(self.telescope),
-                det_name,
-                self.telescope['Detector'].coordSys.origin[2]-4.42942460820456,
-                os.getpid()
-            )
-
     def photon_velocity(self, photon_array, local_wcs, rng) -> np.ndarray:
         """Computes the velocity of the photons directly."""
 
@@ -117,15 +107,6 @@ class RubinOptics(PhotonOp):
             coordSys=self.telescope.stopSurface.coordSys,
         )
         traced = self.telescope.trace(ray_vec)
-        if self.logger:
-            import os
-            self.logger.info(
-                "applyTo id(telescope)=%d detector.name=%s z-origin=%f pid=%d",
-                id(self.telescope),
-                self.detector.getName(),
-                self.telescope['Detector'].coordSys.origin[2]-4.42942460820456,
-                os.getpid()
-            )
         ray_vector_to_photon_array(traced, detector=self.detector, out=photon_array)
         photon_array.x -= self.image_pos.x
         photon_array.y -= self.image_pos.y
@@ -374,7 +355,7 @@ def config_kwargs(config, base, cls):
 @photon_op_type("RubinOptics", input_type="telescope")
 def deserialize_rubin_optics(config, base, _logger):
     kwargs = config_kwargs(config, base, RubinOptics)
-    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope").get("det")
+    telescope = base['det_telescope']
 
     return RubinOptics(
         telescope=telescope,
@@ -392,7 +373,7 @@ def deserialize_rubin_optics(config, base, _logger):
 def deserialize_rubin_diffraction_optics(config, base, _logger):
     kwargs = config_kwargs(config, base, RubinDiffractionOptics)
     opsim_meta = get_opsim_meta(config, base)
-    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope").get("det")
+    telescope = base['det_telescope']
     rubin_diffraction = RubinDiffraction(
         telescope=telescope,
         latitude=kwargs.pop("latitude", RUBIN_LOC.lat.rad),
@@ -424,7 +405,7 @@ def get_camera_cached(camera_name: str):
 def deserialize_rubin_diffraction(config, base, _logger):
     kwargs = config_kwargs(config, base, RubinDiffraction)
     opsim_meta = get_opsim_meta(config, base)
-    telescope = galsim.config.GetInputObj("telescope", config, base, "telescope").get("det")
+    telescope = base['det_telescope']
 
     return RubinDiffraction(
         telescope=telescope,

--- a/imsim/photon_ops.py
+++ b/imsim/photon_ops.py
@@ -52,8 +52,7 @@ class RubinOptics(PhotonOp):
         image_pos,
         icrf_to_field,
         det_name,
-        camera,
-        logger=None
+        camera
     ):
         self.telescope = telescope
         self.detector = camera[det_name]
@@ -61,7 +60,6 @@ class RubinOptics(PhotonOp):
         self.sky_pos = sky_pos
         self.image_pos = image_pos
         self.icrf_to_field = icrf_to_field
-        self.logger = logger
 
     def photon_velocity(self, photon_array, local_wcs, rng) -> np.ndarray:
         """Computes the velocity of the photons directly."""
@@ -364,7 +362,6 @@ def deserialize_rubin_optics(config, base, _logger):
         icrf_to_field=base["_icrf_to_field"],
         det_name=base["det_name"],
         camera=get_camera_cached(kwargs.pop("camera")),
-        logger=_logger,
         **kwargs,
     )
 

--- a/imsim/photon_ops.py
+++ b/imsim/photon_ops.py
@@ -53,6 +53,7 @@ class RubinOptics(PhotonOp):
         icrf_to_field,
         det_name,
         camera,
+        logger=None
     ):
         self.telescope = telescope
         self.detector = camera[det_name]
@@ -60,6 +61,17 @@ class RubinOptics(PhotonOp):
         self.sky_pos = sky_pos
         self.image_pos = image_pos
         self.icrf_to_field = icrf_to_field
+        self.logger = logger
+
+        if self.logger:
+            import os
+            self.logger.info(
+                "__init__ id(telescope)=%d detector.name=%s z-origin=%f pid=%d",
+                id(self.telescope),
+                det_name,
+                self.telescope['Detector'].coordSys.origin[2]-4.42942460820456,
+                os.getpid()
+            )
 
     def photon_velocity(self, photon_array, local_wcs, rng) -> np.ndarray:
         """Computes the velocity of the photons directly."""
@@ -105,6 +117,15 @@ class RubinOptics(PhotonOp):
             coordSys=self.telescope.stopSurface.coordSys,
         )
         traced = self.telescope.trace(ray_vec)
+        if self.logger:
+            import os
+            self.logger.info(
+                "applyTo id(telescope)=%d detector.name=%s z-origin=%f pid=%d",
+                id(self.telescope),
+                self.detector.getName(),
+                self.telescope['Detector'].coordSys.origin[2]-4.42942460820456,
+                os.getpid()
+            )
         ray_vector_to_photon_array(traced, detector=self.detector, out=photon_array)
         photon_array.x -= self.image_pos.x
         photon_array.y -= self.image_pos.y
@@ -362,6 +383,7 @@ def deserialize_rubin_optics(config, base, _logger):
         icrf_to_field=base["_icrf_to_field"],
         det_name=base["det_name"],
         camera=get_camera_cached(kwargs.pop("camera")),
+        logger=_logger,
         **kwargs,
     )
 

--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -324,7 +324,7 @@ class DetectorTelescope:
         )
         self.logger = logger
 
-    def get_shifted_det(self, z_offset):
+    def get_telescope(self, z_offset):
         """Get a potentially detector-shifted version of the telescope with the given z_offset.
         """
         return self.fiducial.withLocallyShiftedOptic(
@@ -356,7 +356,7 @@ class TelescopeLoader(InputLoader):
             z_offset = ccd_orientation.getHeight()*1.0e-3  # Convert to meters.
         else:
             z_offset = 0
-        det_telescope = input_obj.get_shifted_det(z_offset)
+        det_telescope = input_obj.get_telescope(z_offset)
         base['det_telescope'] = det_telescope
 
 RegisterInputType('telescope', TelescopeLoader(DetectorTelescope))

--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -296,20 +296,11 @@ def load_telescope(
     return telescope
 
 
-class Telescopes:
+class DetectorTelescope:
     """
-    This input class stores one or more batoid telescope instances.
-
-    There is always a base telescope, which is created at the start.
-    This is accessible via telescopes.get('base')
-
-    Whenever `set_shifted_det` is called, then a shifted telescope will
-    be set in the 'det' key, so it will be accessible via telescopes.get('det').
+    Produce a batoid telescope instance appropriate for a particular detector,
+    optionally with a shifted detector position.
     """
-    # Note: We don't use a simple dict for this,  because subscripting doesn't
-    # work correctly through proxies, which will be required whenever using this
-    # in multiprocessing.
-
     _req_params = { 'file_name' : str }
     _opt_params = {
         'rotTelPos': Angle,
@@ -317,32 +308,29 @@ class Telescopes:
         'fea': None,
     }
 
-    def __init__(self, file_name, perturbations=(), rotTelPos=None, cameraName='LSSTCamera', fea=None, logger=None):
-        self._d = {
-            # Always start with the base telescope
-            'base': load_telescope(
-                file_name, perturbations=perturbations,
-                rotTelPos=rotTelPos, cameraName=cameraName,
-                fea=fea
-            )
-        }
+    def __init__(
+        self,
+        file_name,
+        perturbations=(),
+        rotTelPos=None,
+        cameraName='LSSTCamera',
+        fea=None,
+        logger=None
+    ):
+        self.fiducial = load_telescope(
+            file_name, perturbations=perturbations,
+            rotTelPos=rotTelPos, cameraName=cameraName,
+            fea=fea
+        )
         self.logger = logger
-        if self.logger:
-            self.logger.info("Telescopes.__init__ id(base)=%d pid=%d", id(self.get('base')), os.getpid())
 
-    def set_shifted_det(self, z_offset):
-        """Set the 'det' key to a shifted optics version with the given z_offset
+    def get_shifted_det(self, z_offset):
+        """Get a potentially detector-shifted version of the telescope with the given z_offset.
         """
-        self._d['det'] = self._d['base'].withLocallyShiftedOptic(
-                "Detector",
-                [0, 0, -z_offset]  # batoid convention is opposite of DM
-            )
-        # if self.logger:
-        #     self.logger.info("set_shifted_det id(base)=%d id(det)=%d pid=%d", id(self.get('base')), id(self.get('det')), os.getpid())
-
-    def get(self, key):
-        return self._d.get(key)
-
+        return self.fiducial.withLocallyShiftedOptic(
+            "Detector",
+            [0, 0, -z_offset]  # batoid convention is opposite of DM
+        )
 
 class TelescopeLoader(InputLoader):
     """Load a telescope from a yaml file.
@@ -366,13 +354,9 @@ class TelescopeLoader(InputLoader):
         ccd_orientation = camera[det_name].getOrientation()
         if hasattr(ccd_orientation, 'getHeight'):
             z_offset = ccd_orientation.getHeight()*1.0e-3  # Convert to meters.
-            logger.info("Setting CCD z-offset for %s to %.2e m", det_name, z_offset)
         else:
             z_offset = 0
-        input_obj.set_shifted_det(z_offset)
-        if logger:
-            logger.info("setupImage det_name=%s z_offset=%f id(base)=%d id(det)=%d pid=%d", det_name, z_offset, id(input_obj.get('base')), id(input_obj.get('det')), os.getpid())
-            # logger.info("setupImage det_name=%s z_offset=%f pid=%d", det_name, z_offset, os.getpid())
-            # logger.info("setupImage")
+        det_telescope = input_obj.get_shifted_det(z_offset)
+        base['det_telescope'] = det_telescope
 
-RegisterInputType('telescope', TelescopeLoader(Telescopes))
+RegisterInputType('telescope', TelescopeLoader(DetectorTelescope))

--- a/tests/test_telescope_loader.py
+++ b/tests/test_telescope_loader.py
@@ -65,7 +65,7 @@ def test_config_shift():
             config['input']['telescope'],
             config,
             'telescope'
-        ).get('base')
+        ).fiducial
         assert shifted == shifted_ref
 
     # Test out exceptions
@@ -155,7 +155,7 @@ def test_config_rot():
             config['input']['telescope'],
             config,
             'telescope'
-        ).get('base')
+        ).fiducial
         assert rotated == rotated_ref
 
     # Check that we can rotate the camera using rotTelPos
@@ -173,7 +173,7 @@ def test_config_rot():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     assert (
         rotated ==
         telescope.withLocallyRotatedOptic(
@@ -284,7 +284,7 @@ def test_config_zernike_perturbation():
             config['input']['telescope'],
             config,
             'telescope'
-        ).get('base')
+        ).fiducial
         assert perturbed == ref
 
     # Test that we can set more than one Zernike at a time,
@@ -342,7 +342,7 @@ def test_config_zernike_perturbation():
             config['input']['telescope'],
             config,
             'telescope'
-        ).get('base')
+        ).fiducial
         assert perturbed == ref
 
 
@@ -381,7 +381,7 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     assert ref == perturbed
 
     # Next is M2 -dx and +dy
@@ -413,7 +413,7 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     assert ref == perturbed
 
     # Next is M2 -Rx and Ry in arcsec
@@ -445,7 +445,7 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     # Just get close for this one since it depends slightly on order of applying
     # X,Y rotations.
     np.testing.assert_allclose(
@@ -483,7 +483,7 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     assert ref == perturbed
 
     # Next is camera -dx and +dy
@@ -515,7 +515,7 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     assert ref == perturbed
 
     # Next is camera -Rx and Ry in arcsec
@@ -547,7 +547,7 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial
     # Just get close for this one since it depends slightly on order of applying
     # X,Y rotations.
     np.testing.assert_allclose(
@@ -610,4 +610,4 @@ def test_config_fea():
         config['input']['telescope'],
         config,
         'telescope'
-    ).get('base')
+    ).fiducial


### PR DESCRIPTION
Fixes #338 .

The original problem was that shifting the detector z-position occurred in a single global variable: `Telescopes._d`.  So competing processes would inevitably clobber each others shifted telescope objects leading to the reported race condition.  The solution suggested by @rmjarvis is to store the detector-shifted telescope instances into the `base` config dict, of which each process has its own copy.

In addition to the above change, I added some logger infrastructure in a few places and added a small optimization to `BatoidWCSFactory._field_to_focal`.