### PR TITLE
Seed is an integer

### DIFF
--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -67,7 +67,7 @@ def parse_fea(config, base, telescope):
     # be supplied.
     fea:
       m1m3_gravity:
-        zenith_angle: 30 deg
+        zenith: 30 deg
 
 
     # Set M1M3 temperature induced figure perturbations.  This requires
@@ -84,14 +84,14 @@ def parse_fea(config, base, telescope):
     # fractional random error to apply to each force actuator.
     fea:
       m1m3_lut:
-        zenith_angle: 39 deg
+        zenith: 39 deg
         error: 0.01  # fractional random error to apply to each actuator
         seed: 1  # random seed for error above
 
     # Set M2 gravitational perturbations.  Requires zenith angle.
     fea:
       m2_gravity:
-        zenith_angle: 30 deg
+        zenith: 30 deg
 
     # Set M2 temperature gradient induced figure errors.  Requires 2 temperature
     # gradients (in the z and radial directions).
@@ -104,8 +104,8 @@ def parse_fea(config, base, telescope):
     # rotator angle.
     fea:
       camera_gravity:
-        zenith_angle: 30 deg
-        rotation_angle: -25 deg
+        zenith: 30 deg
+        rotation: -25 deg
 
     # Set camera temperature-induced perturbations.  Requires the bulk
     # temperature of the camera.

--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -139,17 +139,15 @@ def parse_fea(config, base, telescope):
     builder = LSSTBuilder(telescope, fea_dir=fea_dir, bend_dir=bend_dir)
     for k, v in config.items():
         method = getattr(builder, "with_"+k)
-        # parse angles
-        for kk, vv in v.items():
-            if kk.endswith("_angle"):
-                v[kk], safe = ParseValue(v, kk, base, Angle)
-            elif kk == 'dof':
-                v[kk], safe = ParseValue(v, kk, base, None)
-            elif kk == 'seed':
-                v[kk], safe = ParseValue(v, kk, base, int)
-            else:
-                v[kk], safe = ParseValue(v, kk, base, float)
-        builder = method(**v)
+        req = getattr(method, "_req_params", {})
+        opt = getattr(method, "_opt_params", {})
+        single = getattr(method, "_single_params", {})
+        ignore = getattr(method, "_ignore_params", {})
+        kwargs, safe = GetAllParams(
+            v, base,
+            req=req, opt=opt, single=single, ignore=ignore
+        )
+        builder = method(**kwargs)
     return builder.build()
 
 

--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -145,6 +145,8 @@ def parse_fea(config, base, telescope):
                 v[kk], safe = ParseValue(v, kk, base, Angle)
             elif kk == 'dof':
                 v[kk], safe = ParseValue(v, kk, base, None)
+            elif kk == 'seed':
+                v[kk], safe = ParseValue(v, kk, base, int)
             else:
                 v[kk], safe = ParseValue(v, kk, base, float)
         builder = method(**v)

--- a/tests/test_telescope_loader.py
+++ b/tests/test_telescope_loader.py
@@ -580,7 +580,7 @@ def test_config_fea():
                 file_name: LSST_r.yaml
                 fea:
                     m1m3_gravity:
-                        zenith_angle: *zenith
+                        zenith: *zenith
                     m1m3_temperature:
                         m1m3_TBulk: 0.0
                         m1m3_TxGrad: 0.1
@@ -588,17 +588,17 @@ def test_config_fea():
                         m1m3_TzGrad: 0.1
                         m1m3_TrGrad: 0.1
                     m1m3_lut:
-                        zenith_angle: *zenith
+                        zenith: *zenith
                         error: 0.01
                         seed: 1
                     m2_gravity:
-                        zenith_angle: *zenith
+                        zenith: *zenith
                     m2_temperature:
                         m2_TzGrad: 0.1
                         m2_TrGrad: 0.1
                     camera_gravity:
-                        zenith_angle: *zenith
-                        rotation_angle: *rot
+                        zenith: *zenith
+                        rotation: *rot
                     camera_temperature:
                         camera_TBulk: 0.1
         """

--- a/tests/test_telescope_loader.py
+++ b/tests/test_telescope_loader.py
@@ -589,7 +589,7 @@ def test_config_fea():
                         m1m3_TrGrad: 0.1
                     m1m3_lut:
                         zenith_angle: *zenith
-                        error: 0.0
+                        error: 0.01
                         seed: 1
                     m2_gravity:
                         zenith_angle: *zenith


### PR DESCRIPTION
The seed for the rng that introduces errors in the m1m3 lookup table (within batoid_rubin) needs to be an integer.  I didn't notice this before as the test case I created before elided that RNG entirely since the error was set to 0.0.

The fix here is a bit of a hack; I should probably write a more extensive config parser for this someday.  But this should work for the moment and lets me hand off the current main branch of ImSim to the AOS team for further integration.