### PR TITLE
skycat updates for time-varying sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
                 # We need to get batoid onto conda, but for now, this is a separate step.
                 pip install batoid
                 pip install batoid_rubin
-                pip install skyCatalogs==1.4.0-rc4
+                pip install skyCatalogs==1.4.0-rc5
                 conda info
                 conda list
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
                 # We need to get batoid onto conda, but for now, this is a separate step.
                 pip install batoid
                 pip install batoid_rubin
-                pip install skyCatalogs==1.3.0
+                pip install skyCatalogs==1.4.0-rc4
                 conda info
                 conda list
 

--- a/examples/imsim-skycat.yaml
+++ b/examples/imsim-skycat.yaml
@@ -11,7 +11,7 @@ input.sky_catalog:
     file_name: ../tests/data/sky_cat_9683.yaml
     obj_types: [galaxy]   # restrict to galaxies to avoid bright stars
     band: { type: OpsimData, field: band }
-    band: { type: OpsimData, field: mjd }
+    mjd: { type: OpsimData, field: mjd }
 
 input.opsim_data.file_name: ../tests/data/small_opsim_9683.db
 input.opsim_data.visit: 449053

--- a/examples/imsim-skycat.yaml
+++ b/examples/imsim-skycat.yaml
@@ -11,6 +11,7 @@ input.sky_catalog:
     file_name: ../tests/data/sky_cat_9683.yaml
     obj_types: [galaxy]   # restrict to galaxies to avoid bright stars
     band: { type: OpsimData, field: band }
+    band: { type: OpsimData, field: mjd }
 
 input.opsim_data.file_name: ../tests/data/small_opsim_9683.db
 input.opsim_data.visit: 449053

--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -211,7 +211,8 @@ class SkyCatalogLoader(InputLoader):
                'obj_types' : list,
                'max_flux' : float,
                'apply_dc2_dilation': bool,
-               'approx_nobjects': int
+               'approx_nobjects': int,
+               'mjd': float,
               }
         kwargs, safe = galsim.config.GetAllParams(config, base, req=req,
                                                   opt=opt)

--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -15,9 +15,10 @@ class SkyCatalogInterface:
     # https://confluence.lsstcorp.org/display/LKB/LSST+Key+Numbers
     _eff_area = 0.25 * np.pi * 649**2  # cm^2
 
-    def __init__(self, file_name, wcs, band, xsize=4096, ysize=4096, obj_types=None,
-                 skycatalog_root=None, edge_pix=100, max_flux=None, logger=None,
-                 apply_dc2_dilation=False, approx_nobjects=None):
+    def __init__(self, file_name, wcs, band, mjd, xsize=4096, ysize=4096,
+                 obj_types=None, skycatalog_root=None, edge_pix=100,
+                 max_flux=None, logger=None, apply_dc2_dilation=False,
+                 approx_nobjects=None):
         """
         Parameters
         ----------
@@ -27,6 +28,8 @@ class SkyCatalogInterface:
             WCS of the image to render.
         band : str
             LSST band, one of ugrizy
+        mjd : float
+            MJD of the midpoint of the exposure.
         xsize : int
             Size in pixels of CCD in x-direction.
         ysize : int
@@ -60,6 +63,7 @@ class SkyCatalogInterface:
         self.file_name = file_name
         self.wcs = wcs
         self.band = band
+        self.mjd = mjd
         self.xsize = xsize
         self.ysize = ysize
         self.obj_types = obj_types
@@ -170,7 +174,7 @@ class SkyCatalogInterface:
                 scale = np.sqrt(a/b)
                 gsobjs[component] = gsobj.dilate(scale)
 
-        seds = skycat_obj.get_observer_sed_components()
+        seds = skycat_obj.get_observer_sed_components(mjd=self.mjd)
 
         gs_obj_list = []
         for component in gsobjs:
@@ -188,7 +192,7 @@ class SkyCatalogInterface:
 
         # Compute the flux or get the cached value.
         gs_object.flux \
-            = skycat_obj.get_LSST_flux(self.band)*exptime*self._eff_area
+            = skycat_obj.get_LSST_flux(self.band, mjd=self.mjd)*exptime*self._eff_area
 
         if self.max_flux is not None and gs_object.flux > self.max_flux:
             return None

--- a/tests/test_skycat.py
+++ b/tests/test_skycat.py
@@ -13,13 +13,13 @@ def load_test_skycat(apply_dc2_dilation=False):
     opsim_db_file = str(DATA_DIR / "small_opsim_9683.db")
     visit = 449053
     det_name = "R22_S11"  # detector 94
-
     # Make the WCS object.
     opsim_data = imsim.OpsimDataLoader(opsim_db_file, visit=visit)
     boresight = galsim.CelestialCoord(
         ra=opsim_data["fieldRA"] * galsim.degrees,
         dec=opsim_data["fieldDec"] * galsim.degrees,
     )
+    mjd = opsim_data["mjd"]
     rottelpos = opsim_data["rotTelPos"] * galsim.degrees
     obstime = astropy.time.Time(opsim_data["mjd"], format="mjd", scale="tai")
     band = opsim_data["band"]
@@ -35,7 +35,7 @@ def load_test_skycat(apply_dc2_dilation=False):
     skycat_file = str(DATA_DIR / "sky_cat_9683.yaml")
 
     return imsim.SkyCatalogInterface(
-        skycat_file, wcs, band, obj_types=["galaxy"],
+        skycat_file, wcs, band, mjd, obj_types=["galaxy"],
         apply_dc2_dilation=apply_dc2_dilation
     )
 


### PR DESCRIPTION
This entails obtaining the MJD of the exposure and passing that to the `skyCatalogs` functions that return the SED or flux.