### PR TITLE
Remove galsim 2.4 requirement in templates.py

### DIFF
--- a/imsim/templates.py
+++ b/imsim/templates.py
@@ -8,9 +8,4 @@ import os
 import galsim
 from .meta_data import config_dir
 
-# The RegisterTemplate feature was added in GalSim 2.4.
-# This is currently the development branch (main).
-# TODO: Remove this once we can set galsim>=2.4 as a dependency.
-if galsim.version >= '2.4':
-
-    galsim.config.RegisterTemplate('imsim-config', os.path.join(config_dir, 'imsim-config.yaml'))
+galsim.config.RegisterTemplate('imsim-config', os.path.join(config_dir, 'imsim-config.yaml'))


### PR DESCRIPTION
We now need at least GalSim 2.4 to run at all.
So, this should be a imSim requirment.  Removing TODO and if: