### PR TITLE
refactor header processing to use ParseValue

### DIFF
--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -133,50 +133,58 @@ class LSST_CCDBuilder(OutputBuilder):
         image.header['EXPTIME'] = exptime
         image.header['DET_NAME'] = base['det_name']
 
-
-        # Make a copy so we can modify without affecting the original.
+        header_vals = copy.deepcopy(params.get('header', {}))
         opsim_data = copy.deepcopy(get_opsim_data(config, base))
-        # Update using config header values.
-        header_vals = params.pop('header', {})
-        opsim_data.meta.update(header_vals)
 
-        # MJD is the midpoint of the exposure.  51444 = Jan 1, 2000, which is
-        # not a real observing date.
-        image.header['MJD'] = header_vals.pop('mjd', opsim_data.get('mjd', 51444))
-        # MJD-OBS is the start of the exposure
-        mjd_obs = header_vals.pop(
-            'observationStartMJD',
-            opsim_data.get('observationStartMJD', image.header['MJD'])
-        )
-        mjd_end =  mjd_obs + exptime/86400.
+        # Helper function to parse a value with priority:
+        # 1. from header_vals (popped from dict if present)
+        # 2. from opsim_data
+        # 3. specified default
+        def parse(item, type, default):
+            if item in header_vals:
+                val = galsim.config.ParseValue(header_vals, item, base, type)[0]
+                del header_vals[item]
+            else:
+                val = opsim_data.get(item, default)
+            return val
+
+        # Get a few items needed more than once first
+        mjd = parse('mjd', float, 51444.0)
+        mjd_obs = parse('observationStartMJD', float, mjd)
+        mjd_end =  mjd_obs + exptime/86400.0
+        seqnum = parse('seqnum', int, 0)
+        ratel = parse('fieldRA', float, 0.0)
+        dectel = parse('fieldDec', float, 0.0)
+        airmass = parse('airmass', float, 'N/A')
+
+        # Now construct the image header
+        image.header['MJD'] = mjd
         image.header['MJD-OBS'] = mjd_obs, 'Start of exposure'
+        # NOTE: Should this day be the current day,
+        # or the day at the time of the most recent noon?
         dayobs = astropy.time.Time(mjd_obs, format='mjd').strftime('%Y%m%d')
         image.header['DAYOBS'] = dayobs
-        seqnum = opsim_data.get('seqnum', 0)
         image.header['SEQNUM'] = seqnum
-        image.header['CONTRLLR'] = 'P', 'simulated data'  # For simulated data.
+        image.header['CONTRLLR'] = 'P', 'simulated data'
         image.header['OBSID'] = f"IM_P_{dayobs}_{seqnum:06d}"
-        image.header['IMGTYPE'] = header_vals.pop(
-            'image_type',
-            opsim_data.get('image_type', 'SKYEXP')
-        )
-        image.header['REASON'] = opsim_data.get('reason', 'survey')
-        ratel = header_vals.pop('fieldRA', opsim_data.get('fieldRA', 0.))
-        dectel = header_vals.pop('fieldDec', opsim_data.get('fieldDec', 0.))
+        image.header['IMGTYPE'] = parse('image_type', str, 'SKYEXP')
+        image.header['REASON'] = parse('reason', str, 'survey')
         image.header['RATEL'] = ratel
         image.header['DECTEL'] = dectel
         with warnings.catch_warnings():
             # Silence FITS warning about long header keyword
             warnings.simplefilter('ignore')
-            image.header['ROTTELPOS'] = opsim_data.get('rotTelPos', 0.)
-        image.header['FILTER'] = header_vals.pop('band', opsim_data.get('band'))
+            image.header['ROTTELPOS'] = parse('rotTelPos', float, 0.0)
+        image.header['FILTER'] = parse('band', str, 'N/A/')
         image.header['CAMERA'] = base['output']['camera']
         image.header['HASTART'] = opsim_data.getHourAngle(mjd_obs, ratel)
         image.header['HAEND'] = opsim_data.getHourAngle(mjd_end, ratel)
-        image.header['AMSTART'] = header_vals.pop('airmass', opsim_data.get('airmass', 'N/A')), 'airmass at start of exposure'
-        image.header['AMEND'] = image.header['AMSTART'], 'airmass at end of exposure'  # XXX: This is not correct. Does anyone care?
+        image.header['AMSTART'] = airmass
+        image.header['AMEND'] = airmass  # wrong, does anyone care?
 
+        # If there's anything left in header_vals, add it to the header.
         image.header.update(header_vals)
+
         return [ image ]
 
 RegisterOutputType('LSST_CCD', LSST_CCDBuilder())

--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -183,7 +183,10 @@ class LSST_CCDBuilder(OutputBuilder):
         image.header['AMEND'] = airmass  # wrong, does anyone care?
 
         # If there's anything left in header_vals, add it to the header.
-        image.header.update(header_vals)
+        for k in header_vals:
+            image.header[k] = galsim.config.ParseValue(
+                header_vals, k, base, None
+            )[0]
 
         return [ image ]
 

--- a/tests/test_header_keywords.py
+++ b/tests/test_header_keywords.py
@@ -46,7 +46,15 @@ def run_imsim(camera):
               'output.nfiles': 1,
               'output.readout': '',
               'output.dir': 'fits_header_test',
-              'output.truth': ''}
+              'output.truth': '',
+              'output.header': {
+                  'fieldRA': '$boresight.ra.deg',
+                  'fieldDec': '$boresight.dec.deg',
+                  'test1': '$1+2.3',
+                  'test2': '@output.det_num',
+                  'test3': 'banana'
+              }
+             }
 
     galsim.config.Process(config, logger=logger)
 
@@ -63,6 +71,9 @@ def test_header_keywords():
         mjd_obs = mjd + exptime/2./86400.
         np.testing.assert_approx_equal(hdus[0].header['MJD-OBS'], mjd_obs,
                                        significant=7)
+        assert hdus[0].header['TEST1'] == 3.3
+        assert hdus[0].header['TEST2'] == 0
+        assert hdus[0].header['TEST3'] == 'banana'
     os.remove(os.path.join(eimage_file))
     os.removedirs(os.path.dirname(eimage_file))
 


### PR DESCRIPTION
PR to use the galsim config architecture when processing the `output.header` section of a config file to add keywords to output FITS headers.  This way, you can use `Eval` strings like: 
```yaml
output:
  header:
    fieldRA: $boresight.ra.deg
    fieldDec: $boresight.dec.deg
    rotTelPos: $rtp.deg
    airmass: $1/np.cos(zenith)
```