### PR TITLE
Add surface sag as optional output

### DIFF
--- a/imsim/__init__.py
+++ b/imsim/__init__.py
@@ -23,3 +23,4 @@ from .lsst_image import *
 from .checkpoint import *
 from .opd import *
 from .vignetting import *
+from .sag import *

--- a/imsim/opd.py
+++ b/imsim/opd.py
@@ -153,7 +153,7 @@ class OPDBuilder(ExtraOutputBuilder):
             # FITS doesn't know about numpy masked arrays,
             # So just fill in masked values with NaN
             opd_arr.data[opd_arr.mask] = np.nan
-            opd_img = galsim.Image(np.array(opd_arr.data))
+            opd_img = galsim.Image(np.array(opd_arr.data), scale=dx)
             # Add some provenance information to header
             opd_img.header = galsim.fits.FitsHeader()
             opd_img.header['units'] = 'nm', 'OPD units'

--- a/imsim/sag.py
+++ b/imsim/sag.py
@@ -1,0 +1,84 @@
+import galsim
+from galsim.config import ExtraOutputBuilder, RegisterExtraOutput, GetInputObj
+from galsim.config.input import ParseValue, GetAllParams
+import numpy as np
+import batoid
+from .telescope_loader import infer_optic_radii
+
+
+class SagBuilder(ExtraOutputBuilder):
+    """Build surface sag maps.  The sag is the height above or below a plane
+    perpendicular to the optic axis.  It characterizes the shape of the optic.
+
+
+    Required config inputs:
+        file_name: str
+            Name of file to write sag images to.
+
+    Optional config inputs:
+        nx: int
+            Size of sag map images in pixels.  Default: 255.
+    """
+    def initialize(self, data, scratch, config, base, logger):
+        req = {'file_name': str}
+        opt = {'nx': int}
+        kwargs, safe = GetAllParams(config, base, req=req, opt=opt)
+        self.nx = kwargs.pop('nx', 255)
+        self.final_data = None
+
+    def finalize(self, config, base, main_data, logger):
+        telescope = GetInputObj(
+            'telescope',
+            config,
+            base,
+            'opd'
+        ).fiducial
+        self.final_data = []
+
+        xs = np.linspace(-1, 1, self.nx)
+
+        for name, optic in telescope.itemDict.items():
+            if not isinstance(optic, batoid.Interface):
+                continue
+            outer, inner = infer_optic_radii(optic)
+            xx = xs * outer
+            xx, yy = np.meshgrid(xx, xx)
+            rr = np.hypot(xx, yy)
+            ww = np.where((rr <= outer) & (rr >= inner))
+            out = np.nan * np.ones((self.nx, self.nx))
+            out[ww] = optic.surface.sag(xx[ww], yy[ww])
+
+            dx = (xs[1] - xs[0])*outer
+            dy = dx
+
+            x0, y0, z0 = optic.coordSys.origin
+            R = optic.coordSys.rot
+
+            sag_img = galsim.Image(np.array(out.data), scale=dx)
+            # Add some provenance information to header
+            sag_img.header = galsim.fits.FitsHeader()
+            sag_img.header['units'] = 'm', 'sag units'
+            sag_img.header['dx'] = dx, 'image scale (m)'
+            sag_img.header['dy'] = dy, 'image scale (m)'
+            sag_img.header['x0'] = x0, 'surface origin (m)'
+            sag_img.header['y0'] = y0, 'surface origin (m)'
+            sag_img.header['z0'] = z0, 'surface origin (m)'
+            sag_img.header['R00'] = R[0, 0], 'surface orientation matrix'
+            sag_img.header['R01'] = R[0, 1], 'surface orientation matrix'
+            sag_img.header['R02'] = R[0, 2], 'surface orientation matrix'
+            sag_img.header['R10'] = R[1, 0], 'surface orientation matrix'
+            sag_img.header['R11'] = R[1, 1], 'surface orientation matrix'
+            sag_img.header['R12'] = R[1, 2], 'surface orientation matrix'
+            sag_img.header['R20'] = R[2, 0], 'surface orientation matrix'
+            sag_img.header['R21'] = R[2, 1], 'surface orientation matrix'
+            sag_img.header['R22'] = R[2, 2], 'surface orientation matrix'
+            sag_img.header['name'] = name
+            sag_img.header['telescop'] = telescope.name
+            self.final_data.append(sag_img)
+        return self.final_data
+
+    def writeFile(self, file_name, config, base, logger):
+        galsim.fits.writeMulti(self.final_data, file_name=file_name)
+
+
+RegisterExtraOutput('sag', SagBuilder())

--- a/tests/test_opd.py
+++ b/tests/test_opd.py
@@ -91,12 +91,13 @@ def test_opd_zemax():
 
     # Verify that other data made it into the header
     assert hdu.header['units'] == 'nm'
+    scale = 8.36/(255-1)
     np.testing.assert_allclose(
-        hdu.header['dx'], 8.36/(255-1),
+        hdu.header['dx'], scale,
         rtol=1e-10, atol=1e-10
     )
     np.testing.assert_allclose(
-        hdu.header['dy'], 8.36/(255-1),
+        hdu.header['dy'], scale,
         rtol=1e-10, atol=1e-10
     )
     assert hdu.header['thx'] == 1.121
@@ -109,6 +110,21 @@ def test_opd_zemax():
     assert hdu.header['eps'] == 0.612
     assert hdu.header['jmax'] == 28
     assert hdu.header['telescop'] == "LSST"
+    # Test GalSim wrote reasonable WCS keywords
+    np.testing.assert_allclose(
+        hdu.header['GS_SCALE'], scale,
+        rtol=1e-10, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        hdu.header['CD1_1'], scale,
+        rtol=1e-10, atol=1e-10
+    )
+    np.testing.assert_allclose(
+        hdu.header['CD2_2'], scale,
+        rtol=1e-10, atol=1e-10
+    )
+    assert hdu.header['CD1_2'] == 0.0
+    assert hdu.header['CD2_1'] == 0.0
 
 
 def test_opd_wavelength():

--- a/tests/test_opd.py
+++ b/tests/test_opd.py
@@ -37,8 +37,7 @@ def test_opd_zemax():
         config = yaml.safe_load(config)
         galsim.config.ProcessInput(config)
         galsim.config.SetupExtraOutput(config)
-        # Need to mock file_num for following method to be happy:
-        config['file_num'] = 0
+        galsim.config.SetupConfigFileNum(config, 0, 0, 0)
         galsim.config.extra.WriteExtraOutputs(config, None)
 
         # Check the contents of the output file against Zemax references
@@ -135,8 +134,7 @@ def test_opd_wavelength():
         config = yaml.safe_load(config)
         galsim.config.ProcessInput(config)
         galsim.config.SetupExtraOutput(config)
-        # Need to mock file_num for following method to be happy:
-        config['file_num'] = 0
+        galsim.config.SetupConfigFileNum(config, 0, 0, 0)
         galsim.config.extra.WriteExtraOutputs(config, None)
         fn = Path(d) / "opd1.fits"
         hdu1 = fits.open(fn)[0]
@@ -160,8 +158,7 @@ def test_opd_wavelength():
         config = yaml.safe_load(config)
         galsim.config.ProcessInput(config)
         galsim.config.SetupExtraOutput(config)
-        # Need to mock file_num for following method to be happy:
-        config['file_num'] = 0
+        galsim.config.SetupConfigFileNum(config, 0, 0, 0)
         galsim.config.extra.WriteExtraOutputs(config, None)
         fn = Path(d) / "opd2.fits"
         hdu2 = fits.open(fn)[0]

--- a/tests/test_sag.py
+++ b/tests/test_sag.py
@@ -75,3 +75,19 @@ def test_sag():
                 optic.coordSys.rot
             )
             assert hdu.header['telescop'] == "LSST"
+            # Test GalSim wrote reasonable WCS keywords
+            scale = xs[1] - xs[0]
+            np.testing.assert_allclose(
+                hdu.header['GS_SCALE'], scale,
+                rtol=1e-10, atol=1e-10
+            )
+            np.testing.assert_allclose(
+                hdu.header['CD1_1'], scale,
+                rtol=1e-10, atol=1e-10
+            )
+            np.testing.assert_allclose(
+                hdu.header['CD2_2'], scale,
+                rtol=1e-10, atol=1e-10
+            )
+            assert hdu.header['CD1_2'] == 0.0
+            assert hdu.header['CD2_1'] == 0.0

--- a/tests/test_sag.py
+++ b/tests/test_sag.py
@@ -1,0 +1,77 @@
+import textwrap
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import yaml
+import numpy as np
+from astropy.io import fits
+import galsim
+
+import imsim
+
+
+def test_sag():
+    with TemporaryDirectory() as d:
+        config = textwrap.dedent(
+            f"""
+            input:
+                telescope:
+                    file_name: LSST_r.yaml
+                    perturbations:
+                        M2:
+                            shift: [100.e-6, 0.0, 0.0]
+            output:
+                dir: {d}
+                sag:
+                    file_name: sag.fits
+                    nx: 127
+            """
+        )
+
+        config = yaml.safe_load(config)
+        galsim.config.ProcessInput(config)
+        galsim.config.SetupExtraOutput(config)
+        galsim.config.SetupConfigFileNum(config, 0, 0, 0)
+        galsim.config.extra.WriteExtraOutputs(config, None)
+
+        telescope = galsim.config.GetInputObj(
+            'telescope',
+            config,
+            config,
+            'opd'
+        ).fiducial
+
+        # Check the contents of the output file against Zemax references
+        fn = Path(d) / "sag.fits"
+
+        hdulist = fits.open(fn)
+        for hdu in hdulist:
+            hdr = hdu.header
+            sag = hdu.data
+            optic = telescope[hdr['name']]
+
+            # Verify sag
+            xs = np.arange(hdr['NAXIS1'])*hdr['dx']
+            ys = np.arange(hdr['NAXIS2'])*hdr['dy']
+            xs -= np.mean(xs)
+            ys -= np.mean(ys)
+            xx, yy = np.meshgrid(xs, ys)
+            ww = ~np.isnan(sag)
+            np.testing.assert_allclose(
+                sag[ww],
+                optic.surface.sag(xx[ww], yy[ww]),
+            )
+
+            # Verify coordinate system
+            np.testing.assert_allclose(
+                [hdr['x0'], hdr['y0'], hdr['z0']],
+                optic.coordSys.origin
+            )
+
+            np.testing.assert_allclose(
+                [[hdr['R00'], hdr['R01'], hdr['R02']],
+                 [hdr['R10'], hdr['R11'], hdr['R12']],
+                 [hdr['R20'], hdr['R21'], hdr['R22']]],
+                optic.coordSys.rot
+            )
+            assert hdu.header['telescop'] == "LSST"


### PR DESCRIPTION
Adds a `sag` output field for optionally writing out maps of each optical surface's "sag", i.e., the height above or below the surface's vertex along the optic axis.  Addresses #352 .