### PR TITLE
add vignetting named method

### DIFF
--- a/config/imsim-skycat.yaml
+++ b/config/imsim-skycat.yaml
@@ -16,7 +16,8 @@ input.sky_catalog:
 input.opsim_data.file_name: ../tests/data/small_opsim_9683.db
 input.opsim_data.visit: 449053
 
-input.tree_rings.only_dets: [R22_S11]
+input.tree_rings.only_dets: [R22_S11, R22_S12]
+input.checkpoint: ""
 
 # Disable the atmospheric PSF to run faster for testing.
 input.atm_psf: ""
@@ -39,3 +40,5 @@ stamp.world_pos.type: SkyCatWorldPos
 
 output.dir: output # default `fits`
 output.det_num.first: 94
+output.nproc: 2
+output.nfiles: 2

--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -134,7 +134,7 @@ class LSST_CCDBuilder(OutputBuilder):
         image.header['DET_NAME'] = base['det_name']
 
         header_vals = copy.deepcopy(params.get('header', {}))
-        opsim_data = copy.deepcopy(get_opsim_data(config, base))
+        opsim_data = get_opsim_data(config, base)
 
         # Helper function to parse a value with priority:
         # 1. from header_vals (popped from dict if present)

--- a/imsim/lsst_image.py
+++ b/imsim/lsst_image.py
@@ -5,6 +5,7 @@ from galsim.config import RegisterImageType, GetAllParams, GetSky, AddNoise
 from galsim.config.image_scattered import ScatteredImageBuilder
 from .sky_model import SkyGradient
 from .camera import get_camera
+from .vignetting import Vignetting
 
 
 class LSST_ImageBuilder(ScatteredImageBuilder):
@@ -263,7 +264,8 @@ class LSST_ImageBuilder(ScatteredImageBuilder):
             det_name = base['det_name']
             camera = get_camera(self.camera_name)
             logger.info("Applying vignetting according to radial spline model.")
-            sky.array[:] *= self.vignetting(camera[det_name])
+            radii = Vignetting.get_pixel_radii(camera[det_name])
+            sky.array[:] *= self.vignetting.apply_to_radii(radii)
 
         image += sky
 

--- a/imsim/vignetting.py
+++ b/imsim/vignetting.py
@@ -38,9 +38,11 @@ class Vignetting:
         # normalize the vignetting profile.
         self.value_at_zero = self.spline_model(0)
 
-    def __call__(self, det):
+    @staticmethod
+    def get_pixel_radii(det):
         """
-        Return the vignetting for each pixel in a CCD.
+        Return an array of radial distance from the focal plane center for
+        each pixel in a CCD.
 
         Parameters
         ----------
@@ -77,9 +79,14 @@ class Vignetting:
         else:
             yarr, xarr = np.meshgrid(center.y - dx, center.x + dy)
 
-        r = np.sqrt(xarr**2 + yarr**2)
+        pixel_radii = np.sqrt(xarr**2 + yarr**2)
+        return pixel_radii
 
-        return self.spline_model(r)/self.value_at_zero
+    def apply_to_radii(self, radii):
+        return self.spline_model(radii)/self.value_at_zero
+
+    def __call__(self, det):
+        return self.apply_to_radii(self.get_pixel_radii(det))
 
     def at_sky_coord(self, sky_coord, wcs, det):
         """

--- a/tests/test_vignetting.py
+++ b/tests/test_vignetting.py
@@ -48,7 +48,8 @@ def test_vignetting():
         wcs = wcs_factory.getWCS(det)
 
         # Vignetting function evaluated over the entire CCD:
-        image_vignetting = vignetting(det)
+        radii = imsim.Vignetting.get_pixel_radii(det)
+        image_vignetting = vignetting.apply_to_radii(radii)
 
         # Compare with the values at the detector corners, using the
         # corresponding sky coordinates obtained from the WCS for this


### PR DESCRIPTION
* Enable multiprocessing in `config/imsim-skycat.yaml`
* Use `Vignetting.apply_to_radii` instead of `Vignetting.__call__` to avoid problems with proxy objects for multiprocessing
* Compute radii for pixels in a CCD using a static method to work around un-pickleable Detector objects