### PR TITLE
Chromatic seeing

### DIFF
--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -220,7 +220,7 @@ class AtmosphericPSF(object):
         # Tokovinin 2002, PASP, v114, p1156
         # https://dx.doi.org/10.1086/342683
         kolm_seeing = galsim.Kolmogorov(r0_500=r0_500, lam=wavelength).fwhm
-        r0 = r0_500 * (wavelength/500)**1.2
+        r0 = r0_500 * (wavelength/500)**(6./5)
         arg = 1. - 2.183*(r0/L0)**0.356
         factor = np.sqrt(arg) if arg > 0.0 else 0.0
         return kolm_seeing*factor
@@ -232,7 +232,7 @@ class AtmosphericPSF(object):
     @staticmethod
     def _r0_500(wavelength, L0, targetSeeing):
         """Returns r0_500 to use to get target seeing."""
-        r0_500_max = min(1.0, L0*(1./2.183)**(-0.356)*(wavelength/500.)**1.2)
+        r0_500_max = min(1.0, L0*(1./2.183)**(-0.356)*(wavelength/500.)**(6./5))
         r0_500_min = 0.01
         return bisect(
             AtmosphericPSF._seeingResid,

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -325,6 +325,20 @@ class AtmLoader(InputLoader):
         kwargs, _ = galsim.config.GetAllParams(config, base, req=req_params, opt=opt_params)
         logger.debug("kwargs = %s",kwargs)
 
+        # Check that we're not including the optics twice:
+        if kwargs['doOpt']:
+            if 'stamp' in base:
+                if 'photon_ops' in base['stamp']:
+                    ops_types = [op['type'] for op in base['stamp']['photon_ops']]
+                    for op in ops_types:
+                        if op in ['RubinOptics', 'RubinDiffractionOptics']:
+                            warnings.warn(
+                                f"You have included the optics twice!  Once via the "
+                                f"photon operator {op} "
+                                f"and once via AtmosphericPSF with doOpt=True."
+                                f"This is likely a mistake!"
+                            )
+
         # We want this to be set up right at the beginning of the run, before the config
         # stuff has even set up the RNG yet.  So make an rng ourselves based on the
         # random seed in image.random_seed.

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -326,16 +326,17 @@ class AtmLoader(InputLoader):
         logger.debug("kwargs = %s",kwargs)
 
         # Check that we're not including the optics twice:
-        if kwargs['doOpt']:
+        if 'doOpt' not in kwargs or kwargs['doOpt']:
             if 'stamp' in base:
                 if 'photon_ops' in base['stamp']:
                     ops_types = [op['type'] for op in base['stamp']['photon_ops']]
                     for op in ops_types:
                         if op in ['RubinOptics', 'RubinDiffractionOptics']:
+                            import warnings
                             warnings.warn(
                                 f"You have included the optics twice!  Once via the "
-                                f"photon operator {op} "
-                                f"and once via AtmosphericPSF with doOpt=True."
+                                f"photon operator '{op}' "
+                                f"and once via 'atm_psf' with 'doOpt=True'. "
                                 f"This is likely a mistake!"
                             )
 

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -97,7 +97,7 @@ class AtmosphericPSF(object):
                         in units of (1/r0).  default: 0.2
     @param screen_size  Size of the phase screens in meters.  default: 819.2
     @param screen_scale Size of phase screen "pixels" in meters.  default: 0.1
-    @param doOpt        Add in optical phase screens?  default: True
+    @param doOpt        Add in optical phase screens?  default: False
     @param logger       Optional logger.  default: None
     @param nproc        Number of processes to use in creating screens. If None (default),
                         then allocate one process per phase screen, of which there are 6,
@@ -108,7 +108,7 @@ class AtmosphericPSF(object):
     """
     def __init__(self, airmass, rawSeeing, band, boresight, rng,
                  t0=0.0, exptime=30.0, kcrit=0.2,
-                 screen_size=819.2, screen_scale=0.1, doOpt=True, logger=None,
+                 screen_size=819.2, screen_scale=0.1, doOpt=False, logger=None,
                  nproc=None, save_file=None):
         self.airmass = airmass
         self.rawSeeing = rawSeeing
@@ -326,7 +326,7 @@ class AtmLoader(InputLoader):
         logger.debug("kwargs = %s",kwargs)
 
         # Check that we're not including the optics twice:
-        if 'doOpt' not in kwargs or kwargs['doOpt']:
+        if 'doOpt' in kwargs and kwargs['doOpt']:
             if 'stamp' in base:
                 if 'photon_ops' in base['stamp']:
                     ops_types = [op['type'] for op in base['stamp']['photon_ops']]

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -315,7 +315,7 @@ class AtmosphericPSF(object):
                 ),
                 alpha=self.exponent,
                 base_wavelength=self.wlen_eff,
-                zenith_angle=0*galsim.degrees
+                zenith_angle=0*galsim.degrees  # Turns off DCR, since we apply that later using PhotonDCR.
             )
         ]
         if self.second_kick is not None:

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -515,6 +515,7 @@ class LSST_SiliconBuilder(StampBuilder):
                 #       Something like sed.make_tabulated()
                 if (not isinstance(sed._spec, galsim.LookupTable)
                     or sed._spec.interpolant != 'linear'):
+                    # Workaround for https://github.com/GalSim-developers/GalSim/issues/1228
                     f = np.broadcast_to(sed(wave_list), wave_list.shape)
                     new_spec = galsim.LookupTable(wave_list, f, interpolant='linear')
                     new_sed = galsim.SED(

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -515,8 +515,13 @@ class LSST_SiliconBuilder(StampBuilder):
                 #       Something like sed.make_tabulated()
                 if (not isinstance(sed._spec, galsim.LookupTable)
                     or sed._spec.interpolant != 'linear'):
-                    new_spec = galsim.LookupTable(wave_list, sed(wave_list), interpolant='linear')
-                    new_sed = galsim.SED(new_spec, 'nm', 'fphotons')
+                    f = np.broadcast_to(sed(wave_list), wave_list.shape)
+                    new_spec = galsim.LookupTable(wave_list, f, interpolant='linear')
+                    new_sed = galsim.SED(
+                        new_spec,
+                        'nm',
+                        'fphotons' if sed.spectral else '1'
+                    )
                     prof.SED = new_sed
 
                 # Also recurse onto any components.

--- a/tests/test_photon_ops.py
+++ b/tests/test_photon_ops.py
@@ -646,7 +646,8 @@ def test_double_optics_warning():
         'band':  'r',
         'boresight': galsim.CelestialCoord(0*galsim.degrees, 0*galsim.degrees),
         'screen_size': 6.4,
-        'nproc': 1
+        'nproc': 1,
+        'doOpt': True
     }
     with np.testing.assert_warns(UserWarning):
         galsim.config.ProcessInput(config)

--- a/tests/test_photon_ops.py
+++ b/tests/test_photon_ops.py
@@ -627,6 +627,31 @@ def test_ray_vector_to_photon_array():
     np.testing.assert_array_almost_equal(photon_array.flux, np.ones(n_photons))
 
 
+def test_double_optics_warning():
+    config = {
+        **TEST_BASE_CONFIG,
+        'stamp': {
+            'photon_ops': [
+                {'type': 'RubinOptics',}
+            ]
+        },
+        'image': {
+            'type': 'LSST_Image',
+            'random_seed': 1234
+        }
+    }
+    config['input']['atm_psf'] = {
+        'airmass': 1.1,
+        'rawSeeing':  0.6,
+        'band':  'r',
+        'boresight': galsim.CelestialCoord(0*galsim.degrees, 0*galsim.degrees),
+        'screen_size': 6.4,
+        'nproc': 1
+    }
+    with np.testing.assert_warns(UserWarning):
+        galsim.config.ProcessInput(config)
+
+
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k.startswith("test_") and callable(v)]
     for testfn in testfns:

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -311,15 +311,15 @@ class PsfTestCase(unittest.TestCase):
                 'draw_method' : 'phot',
                 'wcs': {
                     'type' : 'Tan',
-                    'dudx' : 0.2,
+                    'dudx' : 0.05,
                     'dudy' : 0.,
                     'dvdx' : 0.,
-                    'dvdy' : 0.2,
+                    'dvdy' : 0.05,
                     'ra' : '@input.atm_psf.boresight.ra',
                     'dec' : '@input.atm_psf.boresight.dec',
                 },
                 'bandpass': bandpass,
-                'size': 31
+                'size': 127
             },
             'gal': {
                 'type': 'DeltaFunction',
@@ -344,7 +344,7 @@ class PsfTestCase(unittest.TestCase):
             np.testing.assert_allclose(
                 sigma400/sigma900,
                 (400/900)**exponent,
-                rtol=0.02  # 2% error on value of around ~1.2 to 1.3
+                rtol=0.001  # 0.1% error on value of around ~1.2 to 1.3
             )
 
 

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -339,7 +339,6 @@ class PsfTestCase(unittest.TestCase):
             config900['input']['atm_psf']['exponent'] = exponent
             config900['gal']['sed'] = sed900
             img900 = galsim.config.BuildImage(config900)
-            img900.wcs = galsim.PixelScale(0.05) # just lie a little bit
             sigma900 = galsim.hsm.FindAdaptiveMom(img900).moments_sigma
 
             np.testing.assert_allclose(


### PR DESCRIPTION
Adds fwhm \propto wave^-0.2 or so effect of chromatic seeing.  I ended up using galsim.ChromaticAtmosphere with the existing imsim AtmosphericPSF, though I had to split apart the parametric optics from the atm to make sure the chromaticity was only applied to the atm component.  I also split out the 2nd kick component of the atmosphere, since I'm pretty sure this shouldn't have the same wavelength dependence (in the case kcrit -> 0 or inf (can't remember which), the second kick becomes an Airy, which would have a wave^+1.0 chromaticity).

I also addressed #376 by making `doOpt` default to False and raising a warning when double counting the optics.

I added a workaround for https://github.com/GalSim-developers/GalSim/issues/1228 in stamp.py:fix_seds().