### PR TITLE
Parse LSSTSiliconBuilder Options in stamp.py

### DIFF
--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -88,15 +88,19 @@ class LSST_SiliconBuilder(StampBuilder):
         # First do a parsing check to make sure that all the options passed to
         # the config are valid and no required options are missing.
 
-        req = {'fft_sb_threshold': float,
+        req = {'fft_sb_thresh': float,
                'airmass': float,
-               'rawseeing': float,
-               'band': str
+               'rawSeeing': float,
+               'band': str,
+               'world_pos': galsim.CelestialCoord,
+               'diffraction_psf': dict
                }
 
         opt = {'max_flux_simple': float,
-               'method': str,
-               'maxN': int
+               'draw_method': str,
+               'maxN': int,
+               'size': int,
+               'photon_ops': dict
                }
 
         galsim.config.CheckAllParams(config, req, opt)

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -84,6 +84,23 @@ class LSST_SiliconBuilder(StampBuilder):
         Returns:
             xsize, ysize, image_pos, world_pos
         """
+
+        # First do a parsing check to make sure that all the options passed to
+        # the config are valid and no required options are missing.
+
+        req = {'fft_sb_threshold': float,
+               'airmass': float,
+               'rawseeing': float,
+               'band': str
+               }
+
+        opt = {'max_flux_simple': float,
+               'method': str,
+               'maxN': int
+               }
+
+        galsim.config.CheckAllParams(config, req, opt)
+
         gal = galsim.config.BuildGSObject(base, 'gal', logger=logger)[0]
         if gal is None:
             raise galsim.config.SkipThisObject('gal is None (invalid parameters)')

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -89,14 +89,14 @@ class LSST_SiliconBuilder(StampBuilder):
         # the config are valid, and no required options are missing.
 
         req = {'fft_sb_thresh': float,
-               'airmass': float,
-               'rawSeeing': float,
                'band': str,
                'world_pos': galsim.CelestialCoord,
                'diffraction_psf': dict
                }
 
-        opt = {'max_flux_simple': float,
+        opt = {'airmass': dict,
+               'rawSeeing': float,
+               'max_flux_simple': float,
                'draw_method': str,
                'maxN': int,
                'size': int,

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from dataclasses import dataclass, fields, MISSING
 import numpy as np
 import galsim
-from galsim.config import StampBuilder, RegisterStampType, GetAllParams, GetInputObj
+from galsim.config import StampBuilder, RegisterStampType, CheckAllParams, GetAllParams, GetInputObj
 from lsst.obs.lsst.translators.lsst import SIMONYI_LOCATION as RUBIN_LOC
 
 from .diffraction_fft import apply_diffraction_psf

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -88,22 +88,10 @@ class LSST_SiliconBuilder(StampBuilder):
         # First do a parsing check to make sure that all the options passed to
         # the config are valid, and no required options are missing.
 
-        req = {'fft_sb_thresh': float,
-               'band': str,
-               'world_pos': galsim.CelestialCoord,
-               'diffraction_psf': dict
-               }
-
-        opt = {'airmass': dict,
-               'rawSeeing': float,
-               'max_flux_simple': float,
-               'draw_method': str,
-               'maxN': int,
-               'size': int,
-               'photon_ops': dict
-               }
-
-        galsim.config.CheckAllParams(config, req, opt)
+        req = {'diffraction_psf': dict}
+        opt = {}
+        ignore = ['fft_sb_thresh', 'band', 'airmass', 'rawSeeing', 'max_flux_simple'] + ignore
+        galsim.config.CheckAllParams(config, req, opt, ignore=ignore)
 
         gal = galsim.config.BuildGSObject(base, 'gal', logger=logger)[0]
         if gal is None:

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -86,7 +86,7 @@ class LSST_SiliconBuilder(StampBuilder):
         """
 
         # First do a parsing check to make sure that all the options passed to
-        # the config are valid and no required options are missing.
+        # the config are valid, and no required options are missing.
 
         req = {'fft_sb_thresh': float,
                'airmass': float,


### PR DESCRIPTION
Add option parsing to the LSST_SiliconBuilder class.

Note that unlike what I reported, the

OpsimDataLoader
TreeRings
Checkpointer

classes do not need to be changed. They are
using the builtin kwargs function from the InputLoader class.