### PR TITLE
remove test code that's being moved to skyCatalogs

### DIFF
--- a/tests/test_skycat.py
+++ b/tests/test_skycat.py
@@ -71,68 +71,6 @@ class SkyCatalogInterfaceTestCase(unittest.TestCase):
             self.assertEqual(pos.ra.deg, row.ra)
             self.assertEqual(pos.dec.deg, row.dec)
 
-    def test_get_wl_params(self):
-        """
-        Check that the computed lensing parameters match the entries
-        in the parquet file.
-        """
-        for index in self.indexes:
-            obj = self.skycat.objects[index]
-            galaxy_id = obj.get_native_attribute('galaxy_id')
-            row = self.df.query(f'galaxy_id == {galaxy_id}').iloc[0]
-            g1, g2, mu = obj.get_wl_params()
-            gamma1 = row['shear_1']
-            gamma2 = row['shear_2']
-            kappa = row['convergence']
-            self.assertAlmostEqual(g1, gamma1/(1. - kappa))
-            self.assertAlmostEqual(g2, gamma2/(1. - kappa))
-            self.assertAlmostEqual(mu, 1./((1. - kappa)**2 - (gamma1**2 + gamma2**2)))
-
-    def test_get_dust(self):
-        """
-        Check that the extinction parameters match the entries in
-        the parquet file.
-        """
-        for index in self.indexes:
-            obj = self.skycat.objects[index]
-            galaxy_id = obj.get_native_attribute('galaxy_id')
-            row = self.df.query(f'galaxy_id == {galaxy_id}').iloc[0]
-            iAv, iRv, gAv, gRv = obj.get_dust()
-            # For galaxies, we use the SED values that have internal
-            # extinction included, so should have iAv=0, iRv=1.
-            self.assertEqual(iAv, 0)
-            self.assertEqual(iRv, 1)
-            self.assertEqual(gAv, row['MW_av'])
-            self.assertEqual(gRv, row['MW_rv'])
-
-    def test_get_gsobject_components(self):
-        """Check some properties of the objects returned by the
-           .get_gsobject_components function."""
-        for index in self.indexes:
-            obj = self.skycat.objects[index]
-            galaxy_id = obj.get_native_attribute('galaxy_id')
-            row = self.df.query(f'galaxy_id == {galaxy_id}').iloc[0]
-            gs_objs = obj.get_gsobject_components(None, None)
-            for component, gs_obj in gs_objs.items():
-                if component in 'disk bulge':
-                    # Check sersic index
-                    self.assertEqual(gs_obj.original.n,
-                                     row[f'sersic_{component}'])
-                elif component == 'knots':
-                    # Check number of knots
-                    self.assertEqual(gs_obj.original.npoints,
-                                     row['n_knots'])
-
-    def test_get_sed_components(self):
-        """Check sed components."""
-        for index in self.indexes:
-            obj = self.skycat.objects[index]
-            galaxy_id = obj.get_native_attribute('galaxy_id')
-            row = self.df.query(f'galaxy_id == {galaxy_id}').iloc[0]
-            seds = obj.get_observer_sed_components()
-            for component, sed in seds.items():
-                if sed is not None:
-                    self.assertEqual(sed.redshift, row['redshift'])
 
 class EmptySkyCatalogInterfaceTestCase(unittest.TestCase):
     """TestCase for empty catalogs."""


### PR DESCRIPTION
This code should have been relocated for some time since it just tests the interfaces in skyCatalogs and isn't imSim-specific.  I've made a [PR at the skyCatalogs repo](https://github.com/LSSTDESC/skyCatalogs/pull/51) to move these tests there.