### PR TITLE
Fix various aspects of the make_fft_psf code.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,8 @@ jobs:
                 export SIMS_SED_LIBRARY_DIR=`pwd`/rubin_sim_data/sims_sed_library
                 cd config
                 # Just check that they haven't gotten stale and produce errors.
-                galsim imsim-user.yaml
                 galsim flat.yaml image.counts_per_pixel=500
                 galsim flat_with_sed.yaml image.counts_per_pixel=5
                 galsim imsim-skycat.yaml image.nobjects=10
+                cd ../examples
+                galsim imsim-user.yaml image.nobjects=10

--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -224,6 +224,8 @@ stamp:
     airmass: { type: OpsimData, field: airmass }
     rawSeeing:  { type: OpsimData, field: rawSeeing }
     band:  { type: OpsimData, field: band }
+    camera: "@output.camera"
+    det_name: "$det_name"  # This is automatically defined by the LSST_CCD output type.
 
     diffraction_psf:
       exptime: { type: OpsimData, field: exptime }

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -510,7 +510,8 @@ Required keywords to set:
     * ``fft_sb_threshold`` = *float_value* (default = 0) Over this number of counts, use a FFT instead of photon shooting for speed.
     * ``airmass`` = *float_value* (default = 1.2) The airmass to use in FFTs
     * ``rawseeing`` = *float_value* (default = 0.7) The FWHM seeing at zenith at 500 nm in arc seconds for FFTs.
-    *  ``band`` = *str_value* (default = None) The filter band of the observation.
+    * ``band`` = *str_value* (default = None) The filter band of the observation.
+    * ``det_name`` = *str_value* The name of the detector.
 
 
 Optional keywords to set:
@@ -519,6 +520,7 @@ Optional keywords to set:
     * ``max_flux_simple`` = *float_value* (default = 100) If the flux is less than this value use a simple SED and apply other speed ups.
     * ``method`` = *str_value* (default = 'auto') Choose between automatically deciding whether to use a FFT of photon shooting ('auto') or manually choose between 'fft' and 'phot'.
     * ``maxN`` = *int_value* (detault = 1.0e6) Set limit on the size of photons batches when drawing the image.
+    * ``camera`` = *str_value* (default = 'LsstCam') The name of the camera to use.
 
 
 Note there is an extra required keyword you must include in the stamp section that configures how diffraction passing through the telescope spiders is handled.

--- a/examples/imsim-user.yaml
+++ b/examples/imsim-user.yaml
@@ -5,7 +5,7 @@ modules:
 # Get most of the configuration from the imSim named template
 template: imsim-config
 
-input.instance_catalog.file_name: $os.environ.get('IMSIM_HOME')+'/imSim/examples/example_instance_catalog.txt'
+input.instance_catalog.file_name: example_instance_catalog.txt
 input.instance_catalog.sed_dir: $os.environ.get('SIMS_SED_LIBRARY_DIR')
 
 input.instance_catalog.sort_mag: False
@@ -13,7 +13,7 @@ input.instance_catalog.sort_mag: False
 input.tree_rings.only_dets: [R22_S11]
 
 input.opsim_data:
-    file_name: $os.environ.get('IMSIM_HOME')+'/imSim/examples/example_instance_catalog.txt'
+    file_name: example_instance_catalog.txt
 
 #image.nobjects: 5
 

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -88,10 +88,12 @@ class LSST_SiliconBuilder(StampBuilder):
         # First do a parsing check to make sure that all the options passed to
         # the config are valid, and no required options are missing.
 
-        req = {'diffraction_psf': dict}
-        opt = {}
+        req = {'diffraction_psf': dict, 'det_name': str}
+        opt = {'camera': str}
+        # For the optional ones we don't need here, can put in ignore, and they will still
+        # be allowed, but not required.
         ignore = ['fft_sb_thresh', 'band', 'airmass', 'rawSeeing', 'max_flux_simple'] + ignore
-        galsim.config.CheckAllParams(config, req, opt, ignore=ignore)
+        params = galsim.config.GetAllParams(config, base, req=req, opt=opt, ignore=ignore)[0]
 
         gal = galsim.config.BuildGSObject(base, 'gal', logger=logger)[0]
         if gal is None:
@@ -110,8 +112,8 @@ class LSST_SiliconBuilder(StampBuilder):
         self.rng = galsim.config.GetRNG(config, base, logger, "LSST_Silicon")
         bandpass = base['bandpass']
         self.image = base['current_image']
-        camera = get_camera(base['output']['camera'])
-        self.det = camera[base['det_name']]
+        camera = get_camera(params.get('camera', 'LsstCam'))
+        self.det = camera[params['det_name']]
         if not hasattr(gal, 'flux'):
             # In this case, the object flux has not been precomputed
             # or cached by the skyCatalogs code.

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -399,7 +399,8 @@ class LSST_SiliconBuilder(StampBuilder):
 
         # Otherwise (high flux object), we might want to switch to fft.  So be a little careful.
         psf = galsim.config.BuildGSObject(base, 'psf', logger=logger)[0]
-        fft_psf = self.make_fft_psf(psf, logger)
+        bandpass = base['bandpass']
+        fft_psf = self.make_fft_psf(psf.evaluateAtWavelength(bandpass.effective_wavelength), logger)
         logger.warning('Object %d has flux = %s.  Check if we should switch to FFT',
                        base['obj_num'], self.realized_flux)
 
@@ -410,7 +411,6 @@ class LSST_SiliconBuilder(StampBuilder):
         # of giving us an underestimate of the max surface brightness.
         # Also note that `max_sb` is in photons/arcsec^2, so multiply by pixel_scale**2
         # to get photons/pixel, which we compare to fft_sb_thresh.
-        bandpass = base['bandpass']
         gal_achrom = self.gal.evaluateAtWavelength(bandpass.effective_wavelength)
         fft_obj = galsim.Convolve(gal_achrom, fft_psf).withFlux(self.realized_flux)
         max_sb = fft_obj.max_sb/2. * self._pixel_scale**2

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -205,10 +205,17 @@ class LSST_SiliconBuilder(StampBuilder):
 
         logger.info('Object %d will use stamp size = %s',base.get('obj_num',0),image_size)
 
-        # Also the position
-        world_pos = galsim.config.ParseWorldPos(config, 'world_pos', base, logger)
-        self.sky_coord = world_pos
-        image_pos = None  # GalSim will figure this out from the wcs.
+        # Determine where this object is going to go:
+        # This is the same as what the base StampBuilder does:
+        if 'image_pos' in config:
+            image_pos = galsim.config.ParseValue(config, 'image_pos', base, galsim.PositionD)[0]
+        else:
+            image_pos = None
+
+        if 'world_pos' in config:
+            world_pos = galsim.config.ParseWorldPos(config, 'world_pos', base, logger)
+        else:
+            world_pos = None
 
         return image_size, image_size, image_pos, world_pos
 
@@ -423,7 +430,7 @@ class LSST_SiliconBuilder(StampBuilder):
             # recompute the realized flux.
             if self.vignetting is not None:
                 flux = self.gal.flux*self.vignetting.at_sky_coord(
-                    self.sky_coord, self.image.wcs, self.det)
+                    base['sky_pos'], self.image.wcs, self.det)
                 self.realized_flux = galsim.PoissonDeviate(self.rng, mean=flux)()
 
             logger.warning('Yes. Use FFT for this object.  max_sb = %.0f > %.0f',

--- a/tests/imsim_test_helpers.py
+++ b/tests/imsim_test_helpers.py
@@ -1,0 +1,39 @@
+# This file has any helper functions/classes that are used by tests from multiple files.
+
+# Copied verbatim from GalSim:
+# https://github.com/GalSim-developers/GalSim/blob/releases/2.4/tests/galsim_test_helpers.py
+class CaptureLog:
+    """A context manager that saves logging output into a string that is accessible for
+    checking in unit tests.
+
+    After exiting the context, the attribute `output` will have the logging output.
+
+    Sample usage:
+
+            >>> with CaptureLog() as cl:
+            ...     cl.logger.info('Do some stuff')
+            >>> assert cl.output == 'Do some stuff'
+
+    """
+    def __init__(self, level=3):
+        from io import StringIO
+        import logging
+
+        logging_levels = { 0: logging.CRITICAL,
+                           1: logging.WARNING,
+                           2: logging.INFO,
+                           3: logging.DEBUG }
+        self.logger = logging.getLogger('CaptureLog')
+        self.logger.setLevel(logging_levels[level])
+        self.stream = StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.logger.addHandler(self.handler)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.handler.flush()
+        self.output = self.stream.getvalue().strip()
+        self.handler.close()
+

--- a/tests/test_diffraction_fft.py
+++ b/tests/test_diffraction_fft.py
@@ -134,6 +134,7 @@ def create_test_config(
                 "enabled": enable_diffraction,
                 "brightness_threshold": 1.0e5,
             },
+            "det_name": "R22_S11",
             **stamp_args,
         },
     }

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -397,11 +397,11 @@ class PsfTestCase(unittest.TestCase):
                     'rotTelPos': "0 deg",
                 },
                 'det_name': 'R22_S11',
-                'world_pos':  {
-                    'type': 'RADec',
-                    'ra' : '@input.atm_psf.boresight.ra',
-                    'dec' : '@input.atm_psf.boresight.dec',
-                },
+                'image_pos': {
+                    'type': 'XY',
+                    'x': 0,
+                    'y': 0,
+                }
             },
             'image' : {
                 'size': 64,


### PR DESCRIPTION
This PR fixes a number of things.

1. First, the PSF we use for FFT drawing needs to be achromatic, so the new ChromaticAtmosphere PSF needs to be evaluated at the bandpass effective wavelength before we do further processing in make_fft_psf.
2. The unit test I wrote to test this discovered that our modified FFT PSF (to make sure not to use the atmospheric screens in FFT mode, which is super slow) doesn't end up with a good match to the one with screens.  There were a few things to change to make it work better:
    a. Get rid of the SecondKick, which we don't need.
    b. Add back in an Airy, which is implicitly part of a SecondKick piece.
    c. Use VonKarman with the L0 from the screen, rather than Kolmogorov
3. The LSST_Silicon stamp type was implicitly dependent on there being an output field using LSST_CCD, which we don't want.  All it needed from that was the det_name.  So now it's a required parameter in LSST_Silicon, where the template config gets that from the output field.
4. It also got the camera from the output field, which again we don't want.  So that's now an optional parameter as per how we set this elsewhere in imsim.

I also added a run of the new examples/imsim-user.yaml to our CI tests to make sure that runs, which is what triggered this bug fix.  Now CI should notice when that breaks.