### PR TITLE
bright galaxy stamp fix

### DIFF
--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -190,9 +190,11 @@ class LSST_SiliconBuilder(StampBuilder):
 
             gal_at_eff_wl = gal.evaluateAtWavelength(bandpass.effective_wavelength)
             # For bright things, defined as having an average of at least 10 photons per
-            # pixel on average, try to be careful about not truncating the surface brightness
+            # pixel on average, or objects for which GalSim's estimate of the image_size is larger
+            # than self._Nmax, compute the image_size using the surface brightness limit, trying
+            # to be careful about not truncating the surface brightness
             # at the edge of the box.
-            if self.realized_flux > 10 * image_size**2:
+            if (self.realized_flux > 10 * image_size**2) or (image_size > self._Nmax):
                 image_size = self._getGoodPhotImageSize([gal_at_eff_wl, psf], keep_sb_level,
                                                         pixel_scale=self._pixel_scale)
 

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -181,11 +181,11 @@ class LSST_SiliconBuilder(StampBuilder):
             # Start with GalSim's estimate of a good box size.
             image_size = obj.getGoodImageSize(self._pixel_scale)
 
-            # Find a postage stamp region to draw onto.  Use (sky noise)/3. as the nominal
+            # Find a postage stamp region to draw onto.  Use (sky noise)/8. as the nominal
             # minimum surface brightness for rendering an extended object.
             base['current_noise_image'] = base['current_image']
             noise_var = galsim.config.CalculateNoiseVariance(base)
-            keep_sb_level = np.sqrt(noise_var)/3.
+            keep_sb_level = np.sqrt(noise_var)/8.
             self._large_object_sb_level = 3*keep_sb_level
 
             gal_at_eff_wl = gal.evaluateAtWavelength(bandpass.effective_wavelength)


### PR DESCRIPTION
Here are three renderings of the galaxy that I mentioned in [this slack thread](https://lsstc.slack.com/archives/CHXKSF3HC/p1673543975668059) at different stages of addressing this issue.  The first image on the left uses the current code in main.  Here the main issue is that the stamp size returned by `.getGoodImageSize` ([here](https://github.com/LSSTDESC/imSim/blob/c42c10884d085b0f82062f4760f3aa237c6a7dac/imsim/stamp.py#L182)) is so large that the stamp has fewer than 10 photons per pixel on average, so that [this line](https://github.com/LSSTDESC/imSim/blob/c42c10884d085b0f82062f4760f3aa237c6a7dac/imsim/stamp.py#L196) isn't executed and the [somewhat brighter sb limit](https://github.com/LSSTDESC/imSim/blob/c42c10884d085b0f82062f4760f3aa237c6a7dac/imsim/stamp.py#L202) is used instead.  After addressing that by testing the `image_size` vs `self._Nmax`, the middle image below is the outcome.  So I lowered the nominal sb limit used by `._getGoodPhotImageSize` from `np.sqrt(noise_var)/3.` to `np.sqrt(noise_var)/8.`.   With that change, the image on the right is the result.

![bug-fix_stages](https://github.com/LSSTDESC/imSim/assets/1994473/be316126-8d88-4bfd-a16b-5122f9fe5754)

Note that this fix also needs #394 to work properly for objects like this.
