### PR TITLE
Make RubinBandpass type separated from opsim_data input type.

### DIFF
--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -54,7 +54,7 @@ input:
             type: FormattedStr
             format : LSST_%s.yaml
             items:
-                - { type: OpsimData, field: band }
+                - "$band"
         rotTelPos: $rotTelPos
 
     sky_model:
@@ -69,7 +69,7 @@ input:
         # The first 4 items are required.
         airmass: { type: OpsimData, field: airmass }
         rawSeeing:  { type: OpsimData, field: rawSeeing }
-        band:  { type: OpsimData, field: band }
+        band: "$band"
         boresight: "$boresight"
 
         # Optional parameters:  (Unless otherwise stated, these are the default values.)
@@ -123,7 +123,7 @@ image:
     xsize: "$xsize"
     ysize: "$ysize"
 
-    bandpass: { type: OpsimBandpass }
+    bandpass: { type: RubinBandpass, band: "$band" }
 
     wcs:
         type: Batoid
@@ -201,7 +201,7 @@ stamp:
     max_flux_simple: 100  # When to switch to simple SED
     airmass: { type: OpsimData, field: airmass }
     rawSeeing:  { type: OpsimData, field: rawSeeing }
-    band:  { type: OpsimData, field: band }
+    band: "$band"
     camera: "@output.camera"
     det_name: "$det_name"  # This is automatically defined by the LSST_CCD output type.
 
@@ -251,7 +251,6 @@ stamp:
                 # TODO: Figure out the depth to use for other bands.  Josh found -0.6 for y.
                 # These numbers are in units of pixels.
                 ddepth_dict: {'u':0, 'g':0, 'r':0, 'i':0, 'z':0, 'y':-0.6}
-                sband: { type: OpsimData, field: band }
         -
             type: Refraction
             index_ratio: 3.9  # TODO: This is what Josh used for y band.
@@ -283,7 +282,7 @@ output:
         items:
             - { type: OpsimData, field: observationId }
             - { type: OpsimData, field: snap }
-            - { type: OpsimData, field: band }
+            - "$band"
             - "$det_name"   # A value stored in the dict by LSST_CCD
             - "@output.det_num"
 
@@ -302,7 +301,7 @@ output:
             items:
                 - { type: OpsimData, field: observationId }
                 - { type: OpsimData, field: snap }
-                - { type: OpsimData, field: band }
+                - "$band"
                 - "$det_name"
                 - "@output.det_num"
 
@@ -314,7 +313,7 @@ output:
             items:
                 - { type: OpsimData, field: observationId }
                 - { type: OpsimData, field: snap }
-                - { type: OpsimData, field: band }
+                - "$band"
                 - "$det_name"
                 - "@output.det_num"
         columns:

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -194,21 +194,6 @@ Once the opsim data has been specified you can use those values in other parts o
 
 The ``field`` key is required.
 
-OpSim Bandpass
-^^^^^^^^^^^^^^
-
-Once the metadata information has been specified you can use that information to specify the bandpass in other parts of the YAML file.  Using the LSST band that you specified it will read in the appropriate throughput file amd use it for the bandpass.  An example is shown below.
-
-.. code-block:: yaml
-
-    image:
-        type: LSST_Image
-
-        bandpass: { type: OpsimBandpass }
-
-
-There are no configuration parameters for this class.
-
 Telescope Configuration
 -----------------------
 
@@ -476,6 +461,23 @@ Optional keywords to set:
     *  ``H2O_pressure`` = *float_value* (default = 1 kPa) Water vapor pressure in kPa.
     *  ``wavelength`` = *float_value* (default = effective wavelength of the bandpass of the observation) wavelength of photon to use in nanometers.
     *  ``order`` = *int_value* (default = 3) SIP polynomial order for WCS fit.
+
+Rubin Bandpass
+^^^^^^^^^^^^^^
+
+*imSim* also registers a new Bandpass type, representing the Rubin filter throughputs for each band pass: u, g, r, i, z, or Y.  An example is shown below.
+
+.. code-block:: yaml
+
+    image:
+        type: LSST_Image
+
+        bandpass: { type: RubinBandpass, band: r }
+
+Required keywords to set:
+""""""""""""""""""""""""""
+    * ``band`` = *str_value* The name of the band.  Must be one of {u, g, r, i, z, Y}.
+
 
 Key Name: LSST_Flat
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -465,7 +465,7 @@ Optional keywords to set:
 Rubin Bandpass
 ^^^^^^^^^^^^^^
 
-*imSim* also registers a new Bandpass type, representing the Rubin filter throughputs for each band pass: u, g, r, i, z, or Y.  An example is shown below.
+*imSim* also registers a new Bandpass type, representing the Rubin filter throughputs for each band pass: u, g, r, i, z, or y.  An example is shown below.
 
 .. code-block:: yaml
 
@@ -476,7 +476,7 @@ Rubin Bandpass
 
 Required keywords to set:
 """"""""""""""""""""""""""
-    * ``band`` = *str_value* The name of the band.  Must be one of {u, g, r, i, z, Y}.
+    * ``band`` = *str_value* The name of the band.  Must be one of {u, g, r, i, z, y}.
 
 
 Key Name: LSST_Flat

--- a/imsim/__init__.py
+++ b/imsim/__init__.py
@@ -18,6 +18,7 @@ from .templates import *
 from .photon_ops import *
 from .flat import *
 from .sky_model import *
+from .bandpass import *
 from .telescope_loader import *
 from .lsst_image import *
 from .checkpoint import *

--- a/imsim/bandpass.py
+++ b/imsim/bandpass.py
@@ -1,0 +1,56 @@
+
+import os
+import galsim
+from galsim.config import RegisterBandpassType
+
+__all__ = ['RubinBandpass']
+
+
+def RubinBandpass(band, logger=None):
+    """Return one of the Rubin bandpasses, specified by the single-letter name.
+
+    The zeropoint is automatically set to the AB zeropoint normalization.
+
+    Parameters
+    ----------
+    band : `str`
+        The name of the bandpass.  One of u,g,r,i,z,y.
+    logger : logging.Logger
+        If provided, a logger for logging debug statements.
+    """
+    # This uses the baseline throughput files from lsst.sims
+    sims_dir = os.getenv("RUBIN_SIM_DATA_DIR")
+    file_name = os.path.join(sims_dir, "throughputs", "baseline", f"total_{band}.dat")
+    if not os.path.isfile(file_name):
+        # If the user doesn't have the RUBIN_SIM_DATA_DIR defined, or if they don't have
+        # the correct files installed, revert to the GalSim files.
+        logger = galsim.config.LoggerWrapper(logger)
+        logger.warning("Warning: Using the old bandpass files from GalSim, not lsst.sims")
+        file_name = f"LSST_{band}.dat"
+    bp = galsim.Bandpass(file_name, wave_type='nm')
+    bp = bp.thin()
+    bp = bp.withZeropoint('AB')
+    return bp
+
+class RubinBandpassBuilder(galsim.config.BandpassBuilder):
+    """A class for building a RubinBandpass in the config file
+    """
+    def buildBandpass(self, config, base, logger):
+        """Build the Bandpass object based on the LSST filter name.
+
+        Parameters:
+            config:     The configuration dict for the bandpass type.
+            base:       The base configuration dict.
+            logger:     If provided, a logger for logging debug statements.
+
+        Returns:
+            the constructed Bandpass object.
+        """
+        req = { 'band' : str }
+        kwargs, safe = galsim.config.GetAllParams(config, base, req=req)
+        kwargs['logger'] = logger
+        bp = RubinBandpass(**kwargs)
+        logger.debug('bandpass = %s', bp)
+        return bp, safe
+
+RegisterBandpassType('RubinBandpass', RubinBandpassBuilder())

--- a/imsim/batoid_wcs.py
+++ b/imsim/batoid_wcs.py
@@ -15,7 +15,7 @@ from galsim.config import WCSBuilder, RegisterWCSType, GetInputObj
 from lsst.obs.lsst.translators.lsst import SIMONYI_LOCATION as RUBIN_LOC
 from .camera import get_camera
 from .utils import pixel_to_focal, focal_to_pixel
-
+from .sky_model import RubinBandpass
 
 # There are 5 coordinate systems to handle.  In order:
 #   ICRF (rc, dc)
@@ -566,7 +566,7 @@ class BatoidWCSBuilder(WCSBuilder):
 
         if wavelength is None:
             if isinstance(bandpass, str):
-                bandpass = galsim.Bandpass('LSST_%s.dat'%bandpass, wave_type='nm')
+                bandpass = RubinBandpass(bandpass)
             wavelength = bandpass.effective_wavelength
 
         if temperature is None:

--- a/imsim/batoid_wcs.py
+++ b/imsim/batoid_wcs.py
@@ -15,7 +15,7 @@ from galsim.config import WCSBuilder, RegisterWCSType, GetInputObj
 from lsst.obs.lsst.translators.lsst import SIMONYI_LOCATION as RUBIN_LOC
 from .camera import get_camera
 from .utils import pixel_to_focal, focal_to_pixel
-from .sky_model import RubinBandpass
+from .bandpass import RubinBandpass
 
 # There are 5 coordinate systems to handle.  In order:
 #   ICRF (rc, dc)

--- a/imsim/opsim_data.py
+++ b/imsim/opsim_data.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy
 import astropy.coordinates
 import pandas as pd
-from galsim.config import InputLoader, RegisterInputType, RegisterValueType, RegisterBandpassType
+from galsim.config import InputLoader, RegisterInputType, RegisterValueType
 import galsim
 from lsst.obs.lsst.translators.lsst import SIMONYI_LOCATION as RUBIN_LOC
 
@@ -373,29 +373,5 @@ def OpsimData(config, base, value_type):
     val = value_type(meta.get(field))
     return val, safe
 
-class RubinBandpass(galsim.config.BandpassBuilder):
-    """A class for loading a Bandpass for a given instcat
-    """
-    def buildBandpass(self, config, base, logger):
-        """Build the Bandpass object based on the LSST filter name.
-
-        Parameters:
-            config:     The configuration dict for the bandpass type.
-            base:       The base configuration dict.
-            logger:     If provided, a logger for logging debug statements.
-
-        Returns:
-            the constructed Bandpass object.
-        """
-        req = { 'band' : str }
-        kwargs, safe = galsim.config.GetAllParams(config, base, req=req)
-        band = kwargs['band']
-        # TODO: Should switch this to use lsst.sims versions.  GalSim files are pretty old.
-        bandpass = galsim.Bandpass('LSST_%s.dat'%band, wave_type='nm')
-        bandpass = bandpass.withZeropoint('AB')
-        logger.debug('bandpass = %s',bandpass)
-        return bandpass, False
-
 RegisterInputType('opsim_data', InputLoader(OpsimDataLoader, file_scope=True, takes_logger=True))
 RegisterValueType('OpsimData', OpsimData, [float, int, str], input_type='opsim_data')
-RegisterBandpassType('RubinBandpass', RubinBandpass())

--- a/imsim/opsim_data.py
+++ b/imsim/opsim_data.py
@@ -373,7 +373,7 @@ def OpsimData(config, base, value_type):
     val = value_type(meta.get(field))
     return val, safe
 
-class OpsimBandpass(galsim.config.BandpassBuilder):
+class RubinBandpass(galsim.config.BandpassBuilder):
     """A class for loading a Bandpass for a given instcat
     """
     def buildBandpass(self, config, base, logger):
@@ -387,12 +387,10 @@ class OpsimBandpass(galsim.config.BandpassBuilder):
         Returns:
             the constructed Bandpass object.
         """
-        meta = galsim.config.GetInputObj('opsim_data', config, base, 'InstCatWorldPos')
-
-        # Note: Previous code used the lsst.sims versions of these.  Here we just use the ones in
-        #       the GalSim share directory.  Not sure whether those are current, but probably
-        #       good enough for now.
-        band = meta.get('band')
+        req = { 'band' : str }
+        kwargs, safe = galsim.config.GetAllParams(config, base, req=req)
+        band = kwargs['band']
+        # TODO: Should switch this to use lsst.sims versions.  GalSim files are pretty old.
         bandpass = galsim.Bandpass('LSST_%s.dat'%band, wave_type='nm')
         bandpass = bandpass.withZeropoint('AB')
         logger.debug('bandpass = %s',bandpass)
@@ -400,4 +398,4 @@ class OpsimBandpass(galsim.config.BandpassBuilder):
 
 RegisterInputType('opsim_data', InputLoader(OpsimDataLoader, file_scope=True, takes_logger=True))
 RegisterValueType('OpsimData', OpsimData, [float, int, str], input_type='opsim_data')
-RegisterBandpassType('OpsimBandpass', OpsimBandpass(), input_type='opsim_data')
+RegisterBandpassType('RubinBandpass', RubinBandpass())

--- a/imsim/sky_model.py
+++ b/imsim/sky_model.py
@@ -1,15 +1,14 @@
 
-import os
 import copy
 import warnings
 import numpy as np
 import galsim
-from galsim.config import InputLoader, RegisterInputType, RegisterValueType, RegisterBandpassType
+from galsim.config import InputLoader, RegisterInputType, RegisterValueType
 
 RUBIN_AREA = 0.25 * np.pi * 649**2  # cm^2
 
 
-__all__ = ['SkyModel', 'SkyGradient', 'RubinBandpass']
+__all__ = ['SkyModel', 'SkyGradient']
 
 
 class SkyModel:
@@ -134,53 +133,5 @@ def SkyLevel(config, base, value_type):
     value = sky_model.get_sky_level(base['world_center'])
     return value, False
 
-def RubinBandpass(band, logger=None):
-    """Return one of the Rubin bandpasses, specified by the single-letter name.
-
-    The zeropoint is automatically set to the AB zeropoint normalization.
-
-    Parameters
-    ----------
-    band : `str`
-        The name of the bandpass.  One of u,g,r,i,z,y.
-    logger : logging.Logger
-        If provided, a logger for logging debug statements.
-    """
-    # This uses the baseline throughput files from lsst.sims
-    sims_dir = os.getenv("RUBIN_SIM_DATA_DIR")
-    file_name = os.path.join(sims_dir, "throughputs", "baseline", f"total_{band}.dat")
-    if not os.path.isfile(file_name):
-        # If the user doesn't have the RUBIN_SIM_DATA_DIR defined, or if they don't have
-        # the correct files installed, revert to the GalSim files.
-        logger = galsim.config.LoggerWrapper(logger)
-        logger.warning("Warning: Using the old bandpass files from GalSim, not lsst.sims")
-        file_name = f"LSST_{band}.dat"
-    bp = galsim.Bandpass(file_name, wave_type='nm')
-    bp = bp.thin()
-    bp = bp.withZeropoint('AB')
-    return bp
-
-class RubinBandpassBuilder(galsim.config.BandpassBuilder):
-    """A class for building a RubinBandpass in the config file
-    """
-    def buildBandpass(self, config, base, logger):
-        """Build the Bandpass object based on the LSST filter name.
-
-        Parameters:
-            config:     The configuration dict for the bandpass type.
-            base:       The base configuration dict.
-            logger:     If provided, a logger for logging debug statements.
-
-        Returns:
-            the constructed Bandpass object.
-        """
-        req = { 'band' : str }
-        kwargs, safe = galsim.config.GetAllParams(config, base, req=req)
-        kwargs['logger'] = logger
-        bp = RubinBandpass(**kwargs)
-        logger.debug('bandpass = %s', bp)
-        return bp, safe
-
 RegisterInputType('sky_model', SkyModelLoader(SkyModel))
 RegisterValueType('SkyLevel', SkyLevel, [float], input_type='sky_model')
-RegisterBandpassType('RubinBandpass', RubinBandpassBuilder())

--- a/imsim/sky_model.py
+++ b/imsim/sky_model.py
@@ -147,8 +147,21 @@ class RubinBandpass(galsim.Bandpass):
             The name of the bandpass.  One of u,g,r,i,z,Y.
         """
         # TODO: Should switch this to use lsst.sims versions.  GalSim files are pretty old.
-        super().__init__('LSST_%s.dat'%band, wave_type='nm')
+        if False:
+            # I (MJ) believe this is roughlty the code we would want to use here.
+            # But we aren't currently equipped to depend on lsst.sims, so this doesn't work.
+            from lsst.sims.photUtils import BandpassDict
+            bandpassDict = BandpassDict.loadBandpassesFromFiles()[0]
+            bandpass = bandpassDict[bandPassName]
+            index = np.where(bandpass.sb != 0)
+            func = galsim.LookupTable(x=bandpass.wavelen[index], f=bandpass.sb[index])
+            super().__init__(func, wave_type='nm')
+        else:
+            # For now we use the probably mostly close-enough GalSim files.
+            super().__init__('LSST_%s.dat'%band, wave_type='nm')
+
         self.zeropoint = self.withZeropoint('AB').zeropoint
+
 
 class RubinBandpassBuilder(galsim.config.BandpassBuilder):
     """A class for building a RubinBandpass in the config file

--- a/imsim/sky_model.py
+++ b/imsim/sky_model.py
@@ -142,7 +142,7 @@ def RubinBandpass(band, logger=None):
     Parameters
     ----------
     band : `str`
-        The name of the bandpass.  One of u,g,r,i,z,Y.
+        The name of the bandpass.  One of u,g,r,i,z,y.
     logger : logging.Logger
         If provided, a logger for logging debug statements.
     """

--- a/tests/sky_level_reference_values.py
+++ b/tests/sky_level_reference_values.py
@@ -23,7 +23,7 @@ with warnings.catch_warnings():
 
 sky_levels = {}
 for band in 'ugrizy':
-    bandpass = galsim.Bandpass(f'LSST_{band}.dat', wave_type='nm')
+    bandpass = galsim.RubinBandpass(band)
     wave, spec = sky_model.returnWaveSpec()
     lut = galsim.LookupTable(wave, spec[0])
     sed = galsim.SED(lut, wave_type='nm', flux_type='flambda')

--- a/tests/test_bandpass.py
+++ b/tests/test_bandpass.py
@@ -1,0 +1,27 @@
+import numpy as np
+import galsim
+from imsim import RubinBandpass
+
+def test_rubin_bandpass():
+    """Check the RubinBandpass functions to check that they are similar to GalSim lsst_*.dat files.
+    """
+    for band in "ugrizy":
+        rubin_bp = RubinBandpass(band)
+        galsim_bp = galsim.Bandpass(f"LSST_{band}.dat", wave_type='nm').thin()
+        print(f'Band = {band}')
+        print('Rubin_bp: ',rubin_bp.blue_limit, rubin_bp.effective_wavelength, rubin_bp.red_limit)
+        print('galsim_bp: ',galsim_bp.blue_limit, galsim_bp.effective_wavelength, galsim_bp.red_limit)
+        # These are quite close.  The only exception is the blue_limit of the u band, where the
+        # old GalSim bandpass is too red.
+        if band == 'u':
+            assert np.isclose(rubin_bp.blue_limit, galsim_bp.blue_limit, atol=20)
+        else:
+            assert np.isclose(rubin_bp.blue_limit, galsim_bp.blue_limit, atol=1)
+        assert np.isclose(rubin_bp.red_limit, galsim_bp.red_limit, atol=1)
+        assert np.isclose(rubin_bp.effective_wavelength, galsim_bp.effective_wavelength, atol=3)
+
+
+if __name__ == "__main__":
+    testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
+    for testfn in testfns:
+        testfn()

--- a/tests/test_batoid_wcs.py
+++ b/tests/test_batoid_wcs.py
@@ -564,7 +564,7 @@ def test_config():
 
     # Default wavelength from bandpass
     del config['image']['wcs']['wavelength']
-    config['bandpass'] = galsim.Bandpass('LSST_r.dat', 'nm')
+    config['bandpass'] = imsim.RubinBandpass('r')
     galsim.config.RemoveCurrent(config['image']['wcs'])
     config = galsim.config.CleanConfig(config)
     galsim.config.ProcessInput(config)
@@ -581,8 +581,8 @@ def test_config():
 
     del config['bandpass']
     config['image']['bandpass'] = {
-        'file_name' : 'LSST_r.dat',
-        'wave_type' : 'nm',
+        'type': 'RubinBandpass',
+        'band' : 'r',
     }
     galsim.config.RemoveCurrent(config['image']['wcs'])
     config = galsim.config.CleanConfig(config)

--- a/tests/test_instcat_parser.py
+++ b/tests/test_instcat_parser.py
@@ -246,7 +246,7 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
 
         ######## test that fluxes are correctly calculated
 
-        bp = galsim.Bandpass('LSST_%s.dat'%md['band'], wave_type='nm').withZeropoint('AB')
+        bp = imsim.RubinBandpass(md['band'])
 
         for det_name in all_wcs:
             wcs = all_wcs[det_name]
@@ -413,7 +413,7 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
 
         ######## test that fluxes are correctly calculated
 
-        bp = galsim.Bandpass('LSST_%s.dat'%md['band'], wave_type='nm').withZeropoint('AB')
+        bp = imsim.RubinBandpass(md['band'])
 
         for det_name in all_wcs:
             wcs = all_wcs[det_name]

--- a/tests/test_sky_model.py
+++ b/tests/test_sky_model.py
@@ -4,7 +4,7 @@ import numpy as np
 import json
 import logging
 import galsim
-from imsim import SkyModel, SkyGradient, make_batoid_wcs
+from imsim import SkyModel, SkyGradient, make_batoid_wcs, RubinBandpass
 
 
 DATA_DIR = Path(__file__).parent / 'data'
@@ -31,7 +31,7 @@ def test_sky_model():
         expected_sky_levels = json.load(fobj)
 
     for band in 'ugrizy':
-        bandpass = galsim.Bandpass(f'LSST_{band}.dat', wave_type='nm')
+        bandpass = RubinBandpass(band)
         sky_model = SkyModel(exptime, mjd, bandpass)
         sky_level = sky_model.get_sky_level(skyCoord)
         np.testing.assert_approx_equal(sky_level, expected_sky_levels[band],
@@ -50,7 +50,7 @@ def test_sky_gradient():
     exptime = 30.
 
     band = 'i'
-    bandpass = galsim.Bandpass(f'LSST_{band}.dat', wave_type='nm')
+    bandpass = RubinBandpass(band)
     sky_model = SkyModel(exptime, mjd, bandpass)
 
     wcs = make_batoid_wcs(ra, dec, rottelpos, mjd, band, 'LsstCam')
@@ -99,7 +99,7 @@ def test_sky_gradient():
             'xsize': image_xsize,
             'ysize': image_xsize,
             'wcs': wcs,
-            'bandpass': bandpass,
+            'bandpass': { "type": "RubinBandpass", "band": band },
             'apply_sky_gradient': True,
             'sky_level': {'type': 'SkyLevel'},
             'nobjects': 0,

--- a/tests/test_sky_model.py
+++ b/tests/test_sky_model.py
@@ -125,25 +125,6 @@ def test_sky_gradient():
     image2 = galsim.config.BuildImage(config, logger=logger)
     assert image2 == image
 
-def test_rubin_bandpass():
-    """Check the RubinBandpass functions to check that they are similar to GalSim lsst_*.dat files.
-    """
-    for band in "ugrizy":
-        rubin_bp = RubinBandpass(band)
-        galsim_bp = galsim.Bandpass(f"LSST_{band}.dat", wave_type='nm').thin()
-        print(f'Band = {band}')
-        print('Rubin_bp: ',rubin_bp.blue_limit, rubin_bp.effective_wavelength, rubin_bp.red_limit)
-        print('galsim_bp: ',galsim_bp.blue_limit, galsim_bp.effective_wavelength, galsim_bp.red_limit)
-        # These are quite close.  The only exception is the blue_limit of the u band, where the
-        # old GalSim bandpass is too red.
-        if band == 'u':
-            assert np.isclose(rubin_bp.blue_limit, galsim_bp.blue_limit, atol=20)
-        else:
-            assert np.isclose(rubin_bp.blue_limit, galsim_bp.blue_limit, atol=1)
-        assert np.isclose(rubin_bp.red_limit, galsim_bp.red_limit, atol=1)
-        assert np.isclose(rubin_bp.effective_wavelength, galsim_bp.effective_wavelength, atol=3)
-
-
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]
     for testfn in testfns:

--- a/tests/test_sky_model.py
+++ b/tests/test_sky_model.py
@@ -125,6 +125,24 @@ def test_sky_gradient():
     image2 = galsim.config.BuildImage(config, logger=logger)
     assert image2 == image
 
+def test_rubin_bandpass():
+    """Check the RubinBandpass functions to check that they are similar to GalSim lsst_*.dat files.
+    """
+    for band in "ugrizy":
+        rubin_bp = RubinBandpass(band)
+        galsim_bp = galsim.Bandpass(f"LSST_{band}.dat", wave_type='nm').thin()
+        print(f'Band = {band}')
+        print('Rubin_bp: ',rubin_bp.blue_limit, rubin_bp.effective_wavelength, rubin_bp.red_limit)
+        print('galsim_bp: ',galsim_bp.blue_limit, galsim_bp.effective_wavelength, galsim_bp.red_limit)
+        # These are quite close.  The only exception is the blue_limit of the u band, where the
+        # old GalSim bandpass is too red.
+        if band == 'u':
+            assert np.isclose(rubin_bp.blue_limit, galsim_bp.blue_limit, atol=20)
+        else:
+            assert np.isclose(rubin_bp.blue_limit, galsim_bp.blue_limit, atol=1)
+        assert np.isclose(rubin_bp.red_limit, galsim_bp.red_limit, atol=1)
+        assert np.isclose(rubin_bp.effective_wavelength, galsim_bp.effective_wavelength, atol=3)
+
 
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k[:5] == 'test_' and callable(v)]

--- a/tests/test_sky_model.py
+++ b/tests/test_sky_model.py
@@ -5,7 +5,8 @@ import json
 import logging
 import galsim
 from imsim import SkyModel, SkyGradient, make_batoid_wcs, RubinBandpass
-
+from unittest import mock
+from imsim_test_helpers import CaptureLog
 
 DATA_DIR = Path(__file__).parent / 'data'
 
@@ -31,7 +32,12 @@ def test_sky_model():
         expected_sky_levels = json.load(fobj)
 
     for band in 'ugrizy':
-        bandpass = RubinBandpass(band)
+        # This regression test used the GalSim bandpasses.
+        # So use them here by mocking that RUBIN_DATA_DIR is not defined.
+        with mock.patch('os.getenv', return_value=''):
+            with CaptureLog() as cl:
+                bandpass = RubinBandpass(band, logger=cl.logger)
+        assert "Using the old bandpass files" in cl.output
         sky_model = SkyModel(exptime, mjd, bandpass)
         sky_level = sky_model.get_sky_level(skyCoord)
         np.testing.assert_approx_equal(sky_level, expected_sky_levels[band],

--- a/tests/test_skycat.py
+++ b/tests/test_skycat.py
@@ -23,9 +23,7 @@ def load_test_skycat(apply_dc2_dilation=False):
     rottelpos = opsim_data["rotTelPos"] * galsim.degrees
     obstime = astropy.time.Time(opsim_data["mjd"], format="mjd", scale="tai")
     band = opsim_data["band"]
-    bandpass = galsim.Bandpass(
-        f"LSST_{band}.dat", wave_type="nm"
-    ).withZeropoint("AB")
+    bandpass = imsim.RubinBandpass(band)
     wcs_builder = imsim.BatoidWCSBuilder()
     telescope = imsim.load_telescope(f"LSST_{band}.yaml", rotTelPos=rottelpos)
     factory = wcs_builder.makeWCSFactory(boresight, obstime, telescope, bandpass=band)

--- a/tests/test_tree_rings.py
+++ b/tests/test_tree_rings.py
@@ -25,7 +25,7 @@ class TreeRingsTestCase(unittest.TestCase):
         """Check reading of tree_ring_parameters file"""
         opsim_data = imsim.OpsimDataLoader(self.instcat_file)
         band = opsim_data['band']
-        bp = galsim.Bandpass('LSST_%s.dat'%band, wave_type='nm')
+        bp = imsim.RubinBandpass(band)
 
         tr_filename = os.path.join(imsim.data_dir, 'tree_ring_data',
                                    'tree_ring_parameters_19mar18.txt')


### PR DESCRIPTION
This addresses #383.  Namely it:

1. Gets rid of OpsimBandpass type.
2. Adds a RubinBandpass type, which takes a `band` parameter.  (Which we can get from OpsimData if desired -- this is the usage that replaces the old OpsimBandpass use case.)
3. Adds a RubinBandpass class in imsim as the implementation of the above config type.  This class currently mimics the old implementation of using the GalSim lsst_{band}.dat files.  I put in the the code that I think would get us the lsst.sims filter throughputs, but we don't currently depend on lsst.sims, so this is just aspirational for now.  We need to think about how we want the do this.