### PR TITLE
Make most stamp parameters optional

### DIFF
--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -205,7 +205,7 @@ stamp:
     camera: "@output.camera"
     det_name: "$det_name"  # This is automatically defined by the LSST_CCD output type.
 
-    diffraction_psf:
+    diffraction_fft:
       exptime: { type: OpsimData, field: exptime }
       azimuth:
         type: Degrees

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -519,6 +519,12 @@ Required keywords to set:
 
     * ``det_name`` = *str_value* (only required if doing vignetting) The name of the detector.
 
+      .. note::
+            If using the output type LSST_CCD, then ``det_name`` will automatically be added
+            to the ``eval_variables`` section for you.  In this case, you can simply use
+            ``det_name: '$det_name'``.  If not using LSST_CCD, then the value should be of a
+            form such as R22_S11.  (This is the central CCD in the focal plane.)
+
 Optional keywords to set:
 """""""""""""""""""""""""
     * ``fft_sb_threshold`` = *float_value* (default = 0) Over this number of counts, use a FFT instead of photon shooting for speed.  If set to 0 don't ever switch to FFT.

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -289,7 +289,8 @@ Key Name: atmosphericPSF
 This keyword enables an atmospheric PSF with 6 randomly generated atmospheric screens.  Photons are raytraced through this atmosphere to produce a realistic atmospheric PSF.
 
 .. warning::
-    You should not attempt to use the option to add parametric optics (through the ``doOpt`` option) if you are using fully ray-traced optics.  Otherwise, you will simulate the optics twice.  See See :ref:`the stamp keyword <stamp-label>` below how to activate the ray-traced mode.
+
+    You should not attempt to use the option to add parametric optics (through the ``doOpt`` option) if you are using fully ray-traced optics.  Otherwise, you will simulate the optics twice.  See :ref:`the stamp keyword <stamp-label>` below how to activate the ray-traced mode.
 
 
 Required keywords to set:
@@ -531,9 +532,8 @@ Optional keywords to set:
     * ``camera`` = *str_value* (default = 'LsstCam') The name of the camera to use.
 
 
-Note there is an extra required diffraction_psf keyword you must include in the stamp section above that configures how diffraction passing through the telescope spiders is handled.  Here is how to configure it.
-
-Key Name: diffraction_psf:
+Note there is an extra required diffraction_fft keyword you must include in the stamp section above that configures how diffraction passing through the telescope spiders is handled.  Here is how to configure it.
+Key Name: diffraction_fft:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Required keywords to set:
@@ -578,7 +578,11 @@ Optional keywords to set:
 type: **RubinDiffraction**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Apply diffractive Effects.
+Apply diffractive effects.
+
+.. warning::
+
+    This only applies to objects rendering using photon shooting.  To be consistent, if you use this, you should also set diffraction_fft as described above.)
 
 Required keywords to set:
 """""""""""""""""""""""""

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -517,11 +517,7 @@ Stamp Type: LSST_Silicon
 Required keywords to set:
 """""""""""""""""""""""""
 
-    * ``airmass`` = *float_value* (default = 1.2) The airmass to use in FFTs
-    * ``rawseeing`` = *float_value* (default = 0.7) The FWHM seeing at zenith at 500 nm in arc seconds for FFTs.
-    * ``band`` = *str_value* (default = None) The filter band of the observation.
-    * ``det_name`` = *str_value* The name of the detector.
-
+    * ``det_name`` = *str_value* (only required if doing vignetting) The name of the detector.
 
 Optional keywords to set:
 """""""""""""""""""""""""
@@ -531,6 +527,9 @@ Optional keywords to set:
     * ``maxN`` = *int_value* (detault = 1.0e6) Set limit on the size of photons batches when drawing the image.
     * ``camera`` = *str_value* (default = 'LsstCam') The name of the camera to use.
     * ``diffraction_fft`` = *dict* (optional) Parameters for implementing the diffraction spikes of FFT-rendered objects. See below.
+    * ``airmass`` = *float_value* (default = 1.2) The airmass to use when estimating the stamp size to use for FFTs
+    * ``rawSeeing`` = *float_value* (default = 0.7) The FWHM seeing at zenith at 500 nm in arc seconds to use when calculating the stamp size to use for FFTs.
+    * ``band`` = *str_value* (default = 'r') The filter band of the observation to use when estimating the stamp size to use for FFTs.
 
 Key Name: diffraction_fft:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -530,9 +530,8 @@ Optional keywords to set:
     * ``method`` = *str_value* (default = 'auto') Choose between automatically deciding whether to use a FFT of photon shooting ('auto') or manually choose between 'fft' and 'phot'.
     * ``maxN`` = *int_value* (detault = 1.0e6) Set limit on the size of photons batches when drawing the image.
     * ``camera`` = *str_value* (default = 'LsstCam') The name of the camera to use.
+    * ``diffraction_fft`` = *dict* (optional) Parameters for implementing the diffraction spikes of FFT-rendered objects. See below.
 
-
-Note there is an extra required diffraction_fft keyword you must include in the stamp section above that configures how diffraction passing through the telescope spiders is handled.  Here is how to configure it.
 Key Name: diffraction_fft:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -56,8 +56,6 @@ class LSST_SiliconBuilder(StampBuilder):
                               wave_type='nm', flux_type='fphotons')
     _Nmax = 4096  # (Don't go bigger than 4096)
 
-    diffraction_fft: DiffractionFFT
-
     def setup(self, config, base, xsize, ysize, ignore, logger):
         """
         Do the initialization and setup for building a postage stamp.

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -164,6 +164,8 @@ class LSST_SiliconBuilder(StampBuilder):
 
             opt = { 'airmass': float, 'rawSeeing': float, 'band': str }
             kwargs = galsim.config.GetAllParams(config, base, opt=opt)[0]
+            # This ends up with all the keys we made earlier.  Select just these three.
+            kwargs = { k:v for k,v in kwargs.items() if k in opt }
             psf = self.Kolmogorov_and_Gaussian_PSF(gsparams=gsparams, **kwargs)
             image_size = psf.getGoodImageSize(self._pixel_scale)
             # No point in this being larger than a CCD.  Cut back to Nmax if larger than this.

--- a/tests/test_diffraction_fft.py
+++ b/tests/test_diffraction_fft.py
@@ -127,7 +127,7 @@ def create_test_config(
                 -0.5253441048502933 * galsim.radians,
             ),
             "size": stamp_size,
-            "diffraction_psf": {
+            "diffraction_fft": {
                 **alt_az,
                 "exptime": exptime,
                 "rotTelPos": rottelpos,
@@ -389,7 +389,7 @@ def test_fft_diffraction_is_similar_to_raytracing_for_0_exptime():
 
     angle, angle_stddev = folded_spike_angle(brightness, c_x, c_y, r_min=10.0)
     expected_angle = (
-        45.0 * galsim.degrees - config["stamp"]["diffraction_psf"]["rotTelPos"]
+        45.0 * galsim.degrees - config["stamp"]["diffraction_fft"]["rotTelPos"]
     )
 
     # 1° tolerance:

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -389,13 +389,6 @@ class PsfTestCase(unittest.TestCase):
                 'rawSeeing': self.opsim_data['rawSeeing'],
                 'band':  self.opsim_data['band'],
 
-                'diffraction_fft': {
-                    'enabled': False,
-                    'exptime': 30,
-                    'azimuth': "0 deg",
-                    'altitude': "60 deg",
-                    'rotTelPos': "0 deg",
-                },
                 'det_name': 'R22_S11',
                 'image_pos': {
                     'type': 'XY',

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -389,7 +389,7 @@ class PsfTestCase(unittest.TestCase):
                 'rawSeeing': self.opsim_data['rawSeeing'],
                 'band':  self.opsim_data['band'],
 
-                'diffraction_psf': {
+                'diffraction_fft': {
                     'enabled': False,
                     'exptime': 30,
                     'azimuth': "0 deg",

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -385,11 +385,10 @@ class PsfTestCase(unittest.TestCase):
                 'fft_sb_thresh': 2.e5,   # When to switch to fft and a simpler PSF and skip silicon
                 'max_flux_simple': 100,  # When to switch to simple SED
 
-                'airmass': self.opsim_data['airmass'],
+                # rawSeeing is a bit big, so need this one to get the right size stamp.
+                # But others (airmass, band) may be omitted in this case.
+                # Also, don't need det_num since not doing vignetting.
                 'rawSeeing': self.opsim_data['rawSeeing'],
-                'band':  self.opsim_data['band'],
-
-                'det_name': 'R22_S11',
                 'image_pos': {
                     'type': 'XY',
                     'x': 0,

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -51,7 +51,7 @@ def create_test_lsst_silicon(faint: bool):
     lsst_silicon = stamp.LSST_SiliconBuilder()
     lsst_silicon.realized_flux = 100 if not faint else 99
     lsst_silicon.rng = mock.Mock()
-    lsst_silicon.diffraction_psf = mock.Mock()
+    lsst_silicon.diffraction_fft = mock.Mock()
     return lsst_silicon
 
 


### PR DESCRIPTION
There are a number of parameters to our stamp type, `LSST_Silicon`, which are currently required, but are really only needed for specific use cases.

1. diffraction_psf is only appropriate if one is using one of our diffraction photon ops.  Making it optional was requested in issue #384.
2. airmass, band, rawSeeing are only needed to calculate an appropriate image size for bright stars.  And there are already reasonable defaults if the user doesn't care about this being super precise.
3. det_num is only needed if one is doing vignetting.

These are now all optional, except det_num, which is required if vignetting is enabled.

Also, I think the name diffraction_psf is confusing here, since it doesn't make clear that this only applied to FFT-rendered objects.  So I switched the name to diffraction_fft.  I also added a not in the docs that point out that it should be enabled if one is using one of our diffraction-enabling photon ops.