### PR TITLE
Add ability to add to OPD directly.

### DIFF
--- a/imsim/opd.py
+++ b/imsim/opd.py
@@ -147,13 +147,25 @@ class OPDBuilder(ExtraOutputBuilder):
                 projection=self.projection,
                 reference=self.reference
             )
+            xx, yy = opd.coords.T
             dx = opd.primitiveVectors[0, 0]
             dy = opd.primitiveVectors[1, 1]
             opd_arr = opd.array*wavelength  # convert from waves to nm
             # FITS doesn't know about numpy masked arrays,
             # So just fill in masked values with NaN
             opd_arr.data[opd_arr.mask] = np.nan
-            opd_img = galsim.Image(np.array(opd_arr.data), scale=dx)
+            opd_img = galsim.Image(np.array(opd_arr.data))
+            opd_img.setCenter(0, 0)
+            world_origin = galsim.PositionD(
+                xx[self.nx//2, self.nx//2],
+                yy[self.nx//2, self.nx//2]
+            )
+
+            opd_img.wcs = galsim.OffsetWCS(
+                scale=dx,
+                origin=galsim.PositionI(0, 0),
+                world_origin=world_origin
+            )
             # Add some provenance information to header
             opd_img.header = galsim.fits.FitsHeader()
             opd_img.header['units'] = 'nm', 'OPD units'

--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -9,35 +9,6 @@ from collections.abc import Sequence
 from .camera import get_camera
 
 
-def infer_optic_radii(optic):
-    """Infer the inner/outer radii of an optic from its obscuration.
-
-    Parameters
-    ----------
-    optic : batoid.Optic
-        The optic from which to infer radii.
-
-    Returns
-    -------
-    R_outer : float
-        The outer radius of the optic.
-    R_inner : float
-        The inner radius of the optic.
-    """
-    obsc = optic.obscuration
-    if obsc is not None:
-        if isinstance(obsc, batoid.obscuration.ObscNegation):
-            obsc = obsc.original
-        if isinstance(obsc, batoid.obscuration.ObscAnnulus):
-            return obsc.outer, obsc.inner
-        if isinstance(obsc, batoid.obscuration.ObscCircle):
-            return obsc.radius, 0.0
-
-    raise ValueError(
-        f"Cannot infer radii for optic {optic.name}"
-    )
-
-
 def parse_xyz(xyz, base):
     if not isinstance(xyz, list) or len(xyz) != 3:
         raise ValueError("Expecting a list of 3 elements")
@@ -263,7 +234,8 @@ def load_telescope(
                             "Must specify both or neither of R_outer and R_inner"
                         )
                     if not R_outer or not R_inner:
-                        R_outer, R_inner = infer_optic_radii(telescope[optic])
+                        R_outer = telescope[optic].R_outer
+                        R_inner = telescope[optic].R_inner
 
                     if 'coef' in pval and 'idx' in pval:
                         raise ValueError(

--- a/tests/test_opd.py
+++ b/tests/test_opd.py
@@ -14,117 +14,124 @@ DATA_DIR = Path(__file__).parent / 'data'
 
 
 def test_opd_zemax():
-    with TemporaryDirectory() as d:
-        config = textwrap.dedent(
-            f"""
-            input:
-                telescope:
-                    file_name: LSST_r.yaml
-                    perturbations:
-                        M2:
-                            shift: [100.e-6, 0.0, 0.0]
-            output:
-                dir: {d}
-                opd:
-                    file_name: opd.fits
-                    wavelength: 694.0  # nm
-                    projection: zemax
-                    fields:
-                        - {{thx: 1.121 deg, thy: 1.231 deg}}
-            """
-        )
+    for nx in [255, 256]:
+        with TemporaryDirectory() as d:
+            config = textwrap.dedent(
+                f"""
+                input:
+                    telescope:
+                        file_name: LSST_r.yaml
+                        perturbations:
+                            M2:
+                                shift: [100.e-6, 0.0, 0.0]
+                output:
+                    dir: {d}
+                    opd:
+                        file_name: opd.fits
+                        wavelength: 694.0  # nm
+                        projection: zemax
+                        nx: {nx}
+                        fields:
+                            - {{thx: 1.121 deg, thy: 1.231 deg}}
+                """
+            )
 
-        config = yaml.safe_load(config)
-        galsim.config.ProcessInput(config)
-        galsim.config.SetupExtraOutput(config)
-        galsim.config.SetupConfigFileNum(config, 0, 0, 0)
-        galsim.config.extra.WriteExtraOutputs(config, None)
+            config = yaml.safe_load(config)
+            galsim.config.ProcessInput(config)
+            galsim.config.SetupExtraOutput(config)
+            galsim.config.SetupConfigFileNum(config, 0, 0, 0)
+            galsim.config.extra.WriteExtraOutputs(config, None)
 
-        # Check the contents of the output file against Zemax references
-        fn = Path(d) / "opd.fits"
-        hdu = fits.open(fn)[0]
+            # Check the contents of the output file against Zemax references
+            fn = Path(d) / "opd.fits"
+            img = galsim.fits.read(str(fn), read_header=True)
+            opd = img.array
+            hdr = img.header
 
-    # Compare computed annular Zernike coefficients in OPD header to values
-    # from Zemax.  For the Zemax run, I used the design file from
-    # https://docushare.lsstcorp.org/docushare/dsweb/View/Collection-2097
-    # specifically, the file
-    # LSST_Ver_3.3_Baseline_Design_Spiders_Baffles.ZMX
-    # with the following modifications:
-    # - I set the stop surface to the baffle just above M1
-    # - I decentered M2 by 100 microns in x
-    with open(
-        DATA_DIR / "LSST_AZ_v3.3_c3_f6_w3_M2_dx_100um.txt",
-        encoding='utf-16-le'
-    ) as f:
-        zk = np.genfromtxt(f, skip_header=32, usecols=(2))
-    for j in range(1, 29):
+        if nx == 255:
+            # Compare computed annular Zernike coefficients in OPD header to values
+            # from Zemax.  For the Zemax run, I used the design file from
+            # https://docushare.lsstcorp.org/docushare/dsweb/View/Collection-2097
+            # specifically, the file
+            # LSST_Ver_3.3_Baseline_Design_Spiders_Baffles.ZMX
+            # with the following modifications:
+            # - I set the stop surface to the baffle just above M1
+            # - I decentered M2 by 100 microns in x
+            with open(
+                DATA_DIR / "LSST_AZ_v3.3_c3_f6_w3_M2_dx_100um.txt",
+                encoding='utf-16-le'
+            ) as f:
+                zk = np.genfromtxt(f, skip_header=32, usecols=(2))
+            for j in range(1, 29):
+                np.testing.assert_allclose(
+                    hdr[f'AZ_{j:03d}'],
+                    zk[j-1]*694.0,  # waves to nm
+                    atol=0.2,  # nm
+                    rtol=1e-3
+                )
+
+            # Compare the OPD image to Zemax reference.  The setup is the same as above.
+            with open(
+                DATA_DIR / "LSST_WF_v3.3_c3_f6_w3_M2_dx_100um.txt",
+                encoding='utf-16-le'
+            ) as f:
+                opd_zemax = np.genfromtxt(f, skip_header=16)
+            opd_zemax = np.flipud(opd_zemax)  # Zemax has opposite y-axis convention
+            opd_zemax = opd_zemax[1:, 1:]  # Zemax has 1-pixel border of zeros
+            opd_zemax *= 694.0  # waves to nm
+
+            # Zemax obnoxiously uses 0.0 for vignetted pixels; batoid/imSim uses NaN
+            # Also, the Zemax model includes the spider.
+            # So only compare non-zero and non-nan pixels.
+
+            w = opd_zemax != 0.0
+            w &= ~np.isnan(opd)
+
+            np.testing.assert_allclose(
+                opd[w],
+                opd_zemax[w],
+                atol=0.01,  # nm
+                rtol=1e-5
+            )
+
+        # Verify that other data made it into the header
+        x, y = img.get_pixel_centers()
+        xx, yy = img.wcs.toWorld(x, y)
+        assert hdr['units'] == 'nm'
+        scale = xx[0,1] - xx[0,0]
         np.testing.assert_allclose(
-            hdu.header[f'AZ_{j:03d}'],
-            zk[j-1]*694.0,  # waves to nm
-            atol=0.2,  # nm
-            rtol=1e-3
+            hdr['dx'], scale,
+            rtol=1e-10, atol=1e-10
         )
-
-    # Compare the OPD image to Zemax reference.  The setup is the same as above.
-    with open(
-        DATA_DIR / "LSST_WF_v3.3_c3_f6_w3_M2_dx_100um.txt",
-        encoding='utf-16-le'
-    ) as f:
-        opd = np.genfromtxt(f, skip_header=16)
-    opd = np.flipud(opd)  # Zemax has opposite y-axis convention
-    opd = opd[1:, 1:]  # Zemax has 1-pixel border of zeros
-    opd *= 694.0  # waves to nm
-
-    # Zemax obnoxiously uses 0.0 for vignetted pixels; batoid/imSim uses NaN
-    # Also, the Zemax model includes the spider.
-    # So only compare non-zero and non-nan pixels.
-
-    w = opd != 0.0
-    w &= ~np.isnan(hdu.data)
-
-    np.testing.assert_allclose(
-        hdu.data[w],
-        opd[w],
-        atol=0.01,  # nm
-        rtol=1e-5
-    )
-
-    # Verify that other data made it into the header
-    assert hdu.header['units'] == 'nm'
-    scale = 8.36/(255-1)
-    np.testing.assert_allclose(
-        hdu.header['dx'], scale,
-        rtol=1e-10, atol=1e-10
-    )
-    np.testing.assert_allclose(
-        hdu.header['dy'], scale,
-        rtol=1e-10, atol=1e-10
-    )
-    assert hdu.header['thx'] == 1.121
-    assert hdu.header['thy'] == 1.231
-    assert hdu.header['r_thx'] == hdu.header['thx']  # rotator not engaged
-    assert hdu.header['r_thy'] == hdu.header['thy']
-    assert hdu.header['wavelen'] == 694.0
-    assert hdu.header['prjct'] == 'zemax'
-    assert hdu.header['sph_ref'] == 'chief'
-    assert hdu.header['eps'] == 0.612
-    assert hdu.header['jmax'] == 28
-    assert hdu.header['telescop'] == "LSST"
-    # Test GalSim wrote reasonable WCS keywords
-    np.testing.assert_allclose(
-        hdu.header['GS_SCALE'], scale,
-        rtol=1e-10, atol=1e-10
-    )
-    np.testing.assert_allclose(
-        hdu.header['CD1_1'], scale,
-        rtol=1e-10, atol=1e-10
-    )
-    np.testing.assert_allclose(
-        hdu.header['CD2_2'], scale,
-        rtol=1e-10, atol=1e-10
-    )
-    assert hdu.header['CD1_2'] == 0.0
-    assert hdu.header['CD2_1'] == 0.0
+        np.testing.assert_allclose(
+            hdr['dy'], scale,
+            rtol=1e-10, atol=1e-10
+        )
+        assert hdr['thx'] == 1.121
+        assert hdr['thy'] == 1.231
+        assert hdr['r_thx'] == hdr['thx']  # rotator not engaged
+        assert hdr['r_thy'] == hdr['thy']
+        assert hdr['wavelen'] == 694.0
+        assert hdr['prjct'] == 'zemax'
+        assert hdr['sph_ref'] == 'chief'
+        assert hdr['eps'] == 0.612
+        assert hdr['jmax'] == 28
+        assert hdr['telescop'] == "LSST"
+        # Test GalSim wrote reasonable WCS keywords
+        np.testing.assert_allclose(
+            hdr['GS_SCALE'], scale,
+            rtol=1e-10, atol=1e-10
+        )
+        np.testing.assert_allclose(
+            hdr['CD1_1'], scale,
+            rtol=1e-10, atol=1e-10
+        )
+        np.testing.assert_allclose(
+            hdr['CD2_2'], scale,
+            rtol=1e-10, atol=1e-10
+        )
+        assert hdr['CD1_2'] == 0.0
+        assert hdr['CD2_1'] == 0.0
 
 
 def test_opd_wavelength():
@@ -155,7 +162,7 @@ def test_opd_wavelength():
         fn = Path(d) / "opd1.fits"
         hdu1 = fits.open(fn)[0]
 
-        # Now repeat but remove the bandpass and explicitly specifiy the
+        # Now repeat but remove the bandpass and explicitly specify the
         # wavelength
         config = textwrap.dedent(
             f"""

--- a/tests/test_photon_ops.py
+++ b/tests/test_photon_ops.py
@@ -653,6 +653,52 @@ def test_double_optics_warning():
         galsim.config.ProcessInput(config)
 
 
+def test_phase_affects_image():
+    # Process without adding additional phase
+    image_pos = galsim.PositionD(3076.4462608524213, 1566.4896702703757)
+    config = {
+        **TEST_BASE_CONFIG,
+        "image_pos": image_pos,  # This would get set appropriately during normal config processing.
+        "stamp": {
+            "photon_ops": [
+                {
+                    "type": "RubinOptics",
+                    "camera": "LsstCam",
+                    "boresight": {
+                        "type": "RADec",
+                        "ra": "1.1047934165124105 radians",
+                        "dec": "-0.5261230452954583 radians",
+                    },
+                }
+            ]
+        },
+    }
+    galsim.config.ProcessInput(config)
+    galsim.config.input.SetupInputsForImage(config, None)
+    [photon_op] = galsim.config.BuildPhotonOps(config["stamp"], "photon_ops", config)
+    pa = create_test_photon_array(n_photons=10000)
+    rng = galsim.BaseDeviate(123)
+    photon_op.applyTo(pa, local_wcs=create_test_wcs(), rng=rng)
+
+    # Now add some phase and process again
+    config = galsim.config.CleanConfig(config)
+    config.update(**TEST_BASE_CONFIG) # restore _icrf_to_field
+    config['input']['telescope']['fea'] = {
+        'extra_zk': {
+            'zk': [0.0]*4+[10.0*620e-9],  # Add a bunch of defocus
+            'eps': 0.612
+        }
+    }
+    galsim.config.ProcessInput(config)
+    galsim.config.input.SetupInputsForImage(config, None)
+    [photon_op] = galsim.config.BuildPhotonOps(config["stamp"], "photon_ops", config)
+    pa2 = create_test_photon_array(n_photons=10000)
+    rng = galsim.BaseDeviate(123)
+    photon_op.applyTo(pa2, local_wcs=create_test_wcs(), rng=rng)
+
+    assert pa2 != pa
+
+
 if __name__ == "__main__":
     testfns = [v for k, v in vars().items() if k.startswith("test_") and callable(v)]
     for testfn in testfns:

--- a/tests/test_photon_ops.py
+++ b/tests/test_photon_ops.py
@@ -4,6 +4,7 @@ import batoid
 from astropy.time import Time
 from astropy import units
 from coord import degrees
+from copy import deepcopy
 
 from imsim import photon_ops, BatoidWCSFactory, get_camera, diffraction
 from imsim.telescope_loader import load_telescope
@@ -441,13 +442,13 @@ def test_config_rubin_diffraction():
     """Check the config interface to RubinDiffraction."""
 
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         "stamp": {
             "photon_ops": [
                 {
                     "type": "RubinDiffraction",
                     "latitude": "-30.24463 degrees",
-                    **TEST_ALT_AZ_CONFIG
+                    **deepcopy(TEST_ALT_AZ_CONFIG)
                 }
             ]
         },
@@ -468,14 +469,14 @@ def test_config_rubin_diffraction_without_field_rotation():
     """Check the config interface to RubinDiffraction."""
 
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         "stamp": {
             "photon_ops": [
                 {
                     "type": "RubinDiffraction",
                     "latitude": "-30.24463 degrees",
                     "disable_field_rotation": True,
-                    **TEST_ALT_AZ_CONFIG
+                    **deepcopy(TEST_ALT_AZ_CONFIG)
                 }
             ]
         },
@@ -498,7 +499,7 @@ def test_config_rubin_diffraction_optics():
 
     image_pos = galsim.PositionD(3076.4462608524213, 1566.4896702703757)
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         "image_pos": image_pos,  # This would get set appropriately during normal config processing.
         "stamp": {
             "photon_ops": [
@@ -511,7 +512,7 @@ def test_config_rubin_diffraction_optics():
                         "dec": "-0.5261230452954583 radians",
                     },
                     "latitude": "-30.24463 degrees",
-                    **TEST_ALT_AZ_CONFIG
+                    **deepcopy(TEST_ALT_AZ_CONFIG)
                 }
             ]
         },
@@ -535,7 +536,7 @@ def test_config_rubin_diffraction_optics_without_field_rotation():
 
     image_pos = galsim.PositionD(3076.4462608524213, 1566.4896702703757)
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         "image_pos": image_pos,  # This would get set appropriately during normal config processing.
         "stamp": {
             "photon_ops": [
@@ -548,7 +549,7 @@ def test_config_rubin_diffraction_optics_without_field_rotation():
                         "dec": "-0.5261230452954583 radians",
                     },
                     "disable_field_rotation": True,
-                    **TEST_ALT_AZ_CONFIG
+                    **deepcopy(TEST_ALT_AZ_CONFIG)
                 }
             ]
         },
@@ -573,7 +574,7 @@ def test_config_rubin_optics():
 
     image_pos = galsim.PositionD(3076.4462608524213, 1566.4896702703757)
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         "image_pos": image_pos,  # This would get set appropriately during normal config processing.
         "stamp": {
             "photon_ops": [
@@ -629,7 +630,7 @@ def test_ray_vector_to_photon_array():
 
 def test_double_optics_warning():
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         'stamp': {
             'photon_ops': [
                 {'type': 'RubinOptics',}
@@ -657,7 +658,7 @@ def test_phase_affects_image():
     # Process without adding additional phase
     image_pos = galsim.PositionD(3076.4462608524213, 1566.4896702703757)
     config = {
-        **TEST_BASE_CONFIG,
+        **deepcopy(TEST_BASE_CONFIG),
         "image_pos": image_pos,  # This would get set appropriately during normal config processing.
         "stamp": {
             "photon_ops": [
@@ -682,7 +683,7 @@ def test_phase_affects_image():
 
     # Now add some phase and process again
     config = galsim.config.CleanConfig(config)
-    config.update(**TEST_BASE_CONFIG) # restore _icrf_to_field
+    config.update(**deepcopy(TEST_BASE_CONFIG)) # restore _icrf_to_field
     config['input']['telescope']['fea'] = {
         'extra_zk': {
             'zk': [0.0]*4+[10.0*620e-9],  # Add a bunch of defocus

--- a/tests/test_sag.py
+++ b/tests/test_sag.py
@@ -11,83 +11,86 @@ import imsim
 
 
 def test_sag():
-    with TemporaryDirectory() as d:
-        config = textwrap.dedent(
-            f"""
-            input:
-                telescope:
-                    file_name: LSST_r.yaml
-                    perturbations:
-                        M2:
-                            shift: [100.e-6, 0.0, 0.0]
-            output:
-                dir: {d}
-                sag:
-                    file_name: sag.fits
-                    nx: 127
-            """
-        )
-
-        config = yaml.safe_load(config)
-        galsim.config.ProcessInput(config)
-        galsim.config.SetupExtraOutput(config)
-        galsim.config.SetupConfigFileNum(config, 0, 0, 0)
-        galsim.config.extra.WriteExtraOutputs(config, None)
-
-        telescope = galsim.config.GetInputObj(
-            'telescope',
-            config,
-            config,
-            'opd'
-        ).fiducial
-
-        # Check the contents of the output file against Zemax references
-        fn = Path(d) / "sag.fits"
-
-        hdulist = fits.open(fn)
-        for hdu in hdulist:
-            hdr = hdu.header
-            sag = hdu.data
-            optic = telescope[hdr['name']]
-
-            # Verify sag
-            xs = np.arange(hdr['NAXIS1'])*hdr['dx']
-            ys = np.arange(hdr['NAXIS2'])*hdr['dy']
-            xs -= np.mean(xs)
-            ys -= np.mean(ys)
-            xx, yy = np.meshgrid(xs, ys)
-            ww = ~np.isnan(sag)
-            np.testing.assert_allclose(
-                sag[ww],
-                optic.surface.sag(xx[ww], yy[ww]),
+    for nx in [127, 128]:  # Make sure works with both odd and even nx
+        with TemporaryDirectory() as d:
+            config = textwrap.dedent(
+                f"""
+                input:
+                    telescope:
+                        file_name: LSST_r.yaml
+                        perturbations:
+                            M2:
+                                shift: [100.e-6, 0.0, 0.0]
+                output:
+                    dir: {d}
+                    sag:
+                        file_name: sag.fits
+                        nx: {nx}
+                """
             )
 
-            # Verify coordinate system
-            np.testing.assert_allclose(
-                [hdr['x0'], hdr['y0'], hdr['z0']],
-                optic.coordSys.origin
-            )
+            config = yaml.safe_load(config)
+            galsim.config.ProcessInput(config)
+            galsim.config.SetupExtraOutput(config)
+            galsim.config.SetupConfigFileNum(config, 0, 0, 0)
+            galsim.config.extra.WriteExtraOutputs(config, None)
 
-            np.testing.assert_allclose(
-                [[hdr['R00'], hdr['R01'], hdr['R02']],
-                 [hdr['R10'], hdr['R11'], hdr['R12']],
-                 [hdr['R20'], hdr['R21'], hdr['R22']]],
-                optic.coordSys.rot
-            )
-            assert hdu.header['telescop'] == "LSST"
-            # Test GalSim wrote reasonable WCS keywords
-            scale = xs[1] - xs[0]
-            np.testing.assert_allclose(
-                hdu.header['GS_SCALE'], scale,
-                rtol=1e-10, atol=1e-10
-            )
-            np.testing.assert_allclose(
-                hdu.header['CD1_1'], scale,
-                rtol=1e-10, atol=1e-10
-            )
-            np.testing.assert_allclose(
-                hdu.header['CD2_2'], scale,
-                rtol=1e-10, atol=1e-10
-            )
-            assert hdu.header['CD1_2'] == 0.0
-            assert hdu.header['CD2_1'] == 0.0
+            telescope = galsim.config.GetInputObj(
+                'telescope',
+                config,
+                config,
+                'opd'
+            ).fiducial
+
+            # Check the contents of the output file against Zemax references
+            fn = Path(d) / "sag.fits"
+            hdu_list = fits.open(fn)
+
+            for ihdu in range(len(hdu_list)):
+                img = galsim.fits.read(hdu_list=hdu_list, hdu=ihdu, read_header=True)
+                sag = img.array
+                hdr = img.header
+                optic = telescope[hdr['name']]
+
+                # Verify sag
+                x, y = img.get_pixel_centers()
+                xx, yy = img.wcs.toWorld(x, y)
+                ww = ~np.isnan(sag)
+                np.testing.assert_allclose(
+                    sag[ww],
+                    optic.surface.sag(xx[ww], yy[ww]),
+                )
+
+                # Verify coordinate system
+                np.testing.assert_allclose(
+                    [hdr['x0'], hdr['y0'], hdr['z0']],
+                    optic.coordSys.origin
+                )
+
+                np.testing.assert_allclose(
+                    [[hdr['R00'], hdr['R01'], hdr['R02']],
+                    [hdr['R10'], hdr['R11'], hdr['R12']],
+                    [hdr['R20'], hdr['R21'], hdr['R22']]],
+                    optic.coordSys.rot
+                )
+                assert hdr['telescop'] == "LSST"
+                # Test GalSim wrote reasonable WCS keywords
+                scale = xx[0,1] - xx[0,0]
+                np.testing.assert_allclose(
+                    hdr['GS_SCALE'], scale,
+                    rtol=1e-10, atol=1e-10
+                )
+                np.testing.assert_allclose(
+                    hdr['CD1_1'], scale,
+                    rtol=1e-10, atol=1e-10
+                )
+                np.testing.assert_allclose(
+                    hdr['CD2_2'], scale,
+                    rtol=1e-10, atol=1e-10
+                )
+                assert hdr['CD1_2'] == 0.0
+                assert hdr['CD2_1'] == 0.0
+
+
+if __name__ == '__main__':
+    test_sag()

--- a/tests/test_telescope_loader.py
+++ b/tests/test_telescope_loader.py
@@ -611,3 +611,10 @@ def test_config_fea():
         config,
         'telescope'
     ).fiducial
+
+
+if __name__ == "__main__":
+    test_config_shift()
+    test_config_rot()
+    test_config_zernike_perturbation()
+    test_config_fea()


### PR DESCRIPTION
This PR adds some features that enable the `with_extra_zk` method inside `batoid_rubin` v0.3.0 (which just landed on PyPI, but might need a few hours to land on conda-forge).  With this method, you can first zero-out and then directly set whatever OPD you want for a given field angle.  (There's a new test targeting the "zero-out" the OPD feature in particular).

Along the way, I made some other changes to the OPD and sag processing and outputs.

On the processing side, I eliminated the ImSim function that inferred each optic's inner and outer radii and instead added this capability to batoid directly (now available in v0.5.0 of batoid, which is on PyPI and conda-forge).  This became useful when I started making the obscurations on optics more detailed, effectively placing simulated masking tape on M1 to help track +x and +y coordinates (see https://lsstc.slack.com/archives/CHXKSF3HC/p1691467190092519?thread_ts=1691456649.673369&cid=CHXKSF3HC for example).  The more detailed obscuration model meant I could no longer easily infer the radii from the obscuration itself, so batoid will now let you set radii directly and fall back to using the obscuration if needed.

On the output side, I put a bit more care into the output WCSs for OPDs and sags such that they connect the data to actual coordinates on surfaces.  The details are slightly different for OPD and sag, mostly because I tried to mimic Zemax's slightly odd behavior in batoid for OPD output.  ImSim derives its OPD WCS directly from the batoid output though, so if I ever change batoid's behavior to be less like Zemax, ImSim will automatically inherit the new behavior.