### PR TITLE
Have atm_psf load opsim_data input if it isn't yet so it can make screens once and share.

### DIFF
--- a/config/imsim-config-instcat.yaml
+++ b/config/imsim-config-instcat.yaml
@@ -10,6 +10,8 @@
 #
 
 # Get most of the configuration from the base imSim config template.
+modules:
+    - imsim
 template: imsim-config
 
 ####################################################################

--- a/config/imsim-config-skycat.yaml
+++ b/config/imsim-config-skycat.yaml
@@ -11,6 +11,8 @@
 #
 
 # Get most of the configuration from the base imSim config template.
+modules:
+    - imsim
 template: imsim-config
 
 ####################################################################

--- a/imsim/atmPSF.py
+++ b/imsim/atmPSF.py
@@ -347,7 +347,7 @@ class AtmLoader(InputLoader):
     def __init__(self):
         # Override some defaults in the base init.
         super().__init__(init_func=AtmosphericPSF,
-                         takes_logger=True, use_proxy=False,
+                         takes_logger=True, use_proxy=False, file_scope=True,
                          worker_init=galsim.phase_screens.initWorker,
                          worker_initargs=galsim.phase_screens.initWorkerArgs)
 


### PR DESCRIPTION
With the recursive templates, opsim_data now gets put after atm_psf in the input list, which means it fails to load at file scope.  ~To make this work, we need to call atm_psf a file_scope input in order for them to get built once and shared for multiple files.~  This will be fixed in GalSim 2.5 (cf. https://github.com/GalSim-developers/GalSim/pull/1239).  This PR has a temporary fix that does the essence of that, but just for atm_psf and opsim_data.