### PR TITLE
bug-fixes for multiprocessing and Gaia stars

### DIFF
--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -99,7 +99,7 @@ class SkyCatalogInterface:
             sky_cat = skyCatalogs.open_catalog(
                 self.file_name, skycatalog_root=self.skycatalog_root)
             self._objects = sky_cat.get_objects_by_region(
-                region, obj_type_set=self.obj_types)
+                region, obj_type_set=self.obj_types, mjd=self.mjd)
             if not self._objects:
                 self.logger.warning("No objects found on image.")
         return self._objects

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, fields, MISSING
 import numpy as np
 import galsim
 from galsim.config import StampBuilder, RegisterStampType, CheckAllParams, GetAllParams, GetInputObj
+from lsst.afw import cameraGeom
 from lsst.obs.lsst.translators.lsst import SIMONYI_LOCATION as RUBIN_LOC
 
 from .diffraction_fft import apply_diffraction_psf
@@ -431,8 +432,10 @@ class LSST_SiliconBuilder(StampBuilder):
             # empirical vignetting function, if it's available, to
             # recompute the realized flux.
             if self.vignetting is not None:
+                pix_to_fp = self.det.getTransform(cameraGeom.PIXELS,
+                                                  cameraGeom.FOCAL_PLANE)
                 flux = self.gal.flux*self.vignetting.at_sky_coord(
-                    base['sky_pos'], self.image.wcs, self.det)
+                    base['sky_pos'], self.image.wcs, pix_to_fp)
                 self.realized_flux = galsim.PoissonDeviate(self.rng, mean=flux)()
 
             logger.warning('Yes. Use FFT for this object.  max_sb = %.0f > %.0f',

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -2,12 +2,11 @@ from functools import lru_cache
 from dataclasses import dataclass, fields, MISSING
 import numpy as np
 import galsim
-from galsim.config import StampBuilder, RegisterStampType, CheckAllParams, GetAllParams, GetInputObj
+from galsim.config import StampBuilder, RegisterStampType, GetAllParams, GetInputObj
 from lsst.afw import cameraGeom
 from lsst.obs.lsst.translators.lsst import SIMONYI_LOCATION as RUBIN_LOC
 
 from .diffraction_fft import apply_diffraction_psf
-from .readout import CcdReadout
 from .camera import get_camera
 
 

--- a/imsim/vignetting.py
+++ b/imsim/vignetting.py
@@ -88,7 +88,7 @@ class Vignetting:
     def __call__(self, det):
         return self.apply_to_radii(self.get_pixel_radii(det))
 
-    def at_sky_coord(self, sky_coord, wcs, det):
+    def at_sky_coord(self, sky_coord, wcs, pix_to_fp):
         """
         Vignetting function value at the specified sky coordinates
         for a particular CCD.
@@ -101,8 +101,9 @@ class Vignetting:
             The WCS for the CCD being considered.  This is used to find
             the location on the focal plane of focused light from the
             sky position.
-        det : lsst.afw.cameraGeom.Detector
-            The Detector object for the CCD being simulated.
+        pix_to_fp : lsst.afw.geom.TransformPoint2ToPoint2
+            Pixel to focal plane transform object obtained from the
+            relevant lsst.afw.cameraGeom.Detector object.
 
         Returns
         -------
@@ -115,8 +116,6 @@ class Vignetting:
         # used with the spline model to obtain the vignetting scale
         # factor.
         pos = wcs.toImage(sky_coord)
-        pix_to_fp = det.getTransform(cameraGeom.PIXELS,
-                                     cameraGeom.FOCAL_PLANE)
         fp_pos = pix_to_fp.applyForward(lsst.geom.Point2D(pos.x, pos.y))
         r = np.sqrt(fp_pos.x**2 + fp_pos.y**2)
 

--- a/tests/data/test_multiproc_instcat.txt
+++ b/tests/data/test_multiproc_instcat.txt
@@ -1,0 +1,29 @@
+#comment
+rightascension 31.1133844
+declination -10.0970060
+mjd 59797.2854090
+altitude 43.6990272
+azimuth 73.7707957
+filter 2
+rotskypos 69.0922930
+rottelpos 1.000
+dist2moon 145.1095257
+moonalt -11.1383568
+moondec -18.7702120
+moonphase 59.6288830
+moonra 230.9832941
+nsnap 2
+seqnum 0
+obshistid 161899
+seed 161899
+seeing 0.7613760
+sunalt -59.1098785
+vistime 33.0000000
+object MS_567_8 31.2400746 -10.09365 15 starSED/phoSimMLT/lte033-4.5-1.0a+0.4.BT-Settl.spec.gz 0 0 0 0 0 0 point none CCM 0.0635117705 3.1
+object 811883456516 31.2338048 -10.0578789 26.9267056 starSED/phoSimMLT/lte027-2.0-0.0a+0.0.BT-Settl.spec.gz 0 0 0 0 0 0 point none CCM 0.0630700848 3.1
+object 1046816368644 31.2371416 -10.0554117 28.7153047 starSED/phoSimMLT/lte027-2.0-0.0a+0.0.BT-Settl.spec.gz 0 0 0 0 0 0 point none CCM 0.0630379733 3.1
+object 1046816356356 31.2305508 -10.0620637 26.7932237 starSED/phoSimMLT/lte033-4.5-1.0a+0.4.BT-Settl.spec.gz 0 0 0 0 0 0 point none CCM 0.0631214889 3.1
+object 1046816650244 31.2225696 -10.0784635 29.2177099 starSED/phoSimMLT/lte032-4.5-1.0a+0.4.BT-Settl.spec.gz 0 0 0 0 0 0 point none CCM 0.0632916884 3.1
+object 275781785604 31.2570189 -10.0836452 23.454705 starSED/phoSimMLT/lte027-2.0-0.0a+0.0.BT-Settl.spec.gz 0 0 0 0 0 0 point none CCM 0.0638548764 3.1
+object 956090372100 31.2608206 -10.0836426 24.218305 starSED/phoSimMLT/lte027-2.0-0.0a+0.0.BT-Settl.spec.gz 0 0 0 0 0 0 point CCM 0.0651282621 3.1 CCM 0.0651282621 3.1
+object 956090392580 31.258544 -10.0948714 24.6497053 starSED/phoSimMLT/lte027-2.0-0.0a+0.0.BT-Settl.spec.gz 0 0 0 0 0 0 point CCM 0.0639515271 3.1 none

--- a/tests/test_multiproc.py
+++ b/tests/test_multiproc.py
@@ -1,0 +1,78 @@
+import os
+import sys
+from pathlib import Path
+import logging
+import unittest
+import galsim
+
+
+class MultiprocTestCase(unittest.TestCase):
+    """TestCase class to test multiprocessing with imSim"""
+    def setUp(self):
+        self.output_dir = 'fits_multiproc_test'
+        self.only_dets = ['R22_S11', 'R22_S12']
+        self.expected_files = []
+        for det_num, det_name in enumerate(self.only_dets):
+            self.expected_files.extend(
+                [os.path.join(self.output_dir,
+                              f'{prefix}_00161899-0-r-{det_name}'
+                              f'-det{det_num:03d}.{suffix}')
+                 for prefix, suffix in [('amp', 'fits.fz'),
+                                        ('eimage', 'fits')]])
+
+    def tearDown(self):
+        """Clean up test output files, if they exist."""
+        for item in self.expected_files:
+            if os.path.isfile(item):
+                os.remove(item)
+        if os.path.isdir(self.output_dir):
+            os.removedirs(self.output_dir)
+
+    def run_imsim(self):
+        imsim_dir = os.path.dirname(os.path.abspath(str(Path(__file__).parent)))
+        os.environ['SIMS_SED_LIBRARY_DIR'] \
+            = os.path.join(imsim_dir, 'tests', 'data', 'test_sed_library')
+        template = os.path.join(imsim_dir, 'config',
+                                'imsim-config-instcat.yaml')
+        instcat_file = os.path.join(imsim_dir, 'tests', 'data',
+                                    'test_multiproc_instcat.txt')
+        logger = logging.getLogger('test_multiproc')
+        if len(logger.handlers) == 0:
+            logger.addHandler(logging.StreamHandler(sys.stdout))
+        logger.setLevel(logging.CRITICAL)  # silence the log messages
+
+        config = {'modules': ['imsim'],
+                  'template': template,
+                  'input.instance_catalog.file_name': instcat_file,
+                  'input.opsim_data.file_name': instcat_file,
+                  'input.tree_rings.only_dets': self.only_dets,
+                  'input.checkpoint': '',
+                  'input.atm_psf': '',
+                  'psf': {'type': 'Convolve',
+                          'items': [{'type': 'Gaussian',
+                                     'fwhm': 0.8},
+                                    {'type': 'Gaussian',
+                                     'fwhm': 0.3}]
+                          },
+                  'image.random_seed': 42,
+                  'stamp.fft_sb_thresh': '1e5',
+                  'output.only_dets': self.only_dets,
+                  'output.det_num.first': 0,
+                  'output.nfiles': 2,
+                  'output.dir': self.output_dir,
+                  'output.truth': '',
+                  'output.nproc': 2,
+                  }
+
+        galsim.config.Process(config, logger=logger, except_abort=True)
+
+    def test_multiproc(self):
+        """Run the 2-process test"""
+        self.run_imsim()
+        # Check that expected files exist.
+        for item in self.expected_files:
+            self.assertTrue(os.path.isfile(item))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vignetting.py
+++ b/tests/test_vignetting.py
@@ -45,6 +45,7 @@ def test_vignetting():
     det_names = ["R00_SG0", "R40_SW0", "R30_S11", "R22_S11"]
     for det_name in det_names:
         det = camera[det_name]
+        pix_to_fp = det.getTransform(cameraGeom.PIXELS, cameraGeom.FOCAL_PLANE)
         wcs = wcs_factory.getWCS(det)
 
         # Vignetting function evaluated over the entire CCD:
@@ -59,7 +60,7 @@ def test_vignetting():
         for corner in corners:
             image_pos = galsim.PositionD(*corner)
             sky_coord = wcs.toWorld(image_pos)
-            sky_value = vignetting.at_sky_coord(sky_coord, wcs, det)
+            sky_value = vignetting.at_sky_coord(sky_coord, wcs, pix_to_fp)
             test_values = sky_value, image_vignetting[corner[1], corner[0]]
             np.testing.assert_almost_equal(*test_values)
 


### PR DESCRIPTION
* With the handling of proper motion and parallax for Gaia stars in skyCatalogs, the function call for accessing the skyCatalogs files needs to have the MJD of the observation provided.
* `lsst.afw.cameraGeom.Detector` objects are not pickleable, so just pass the transformation object to the `Vignetting.at_sky_coord` function since the `Vignetting` instance is a proxy object when using multiprocessing, and it therefore needs to be passed pickleable arguments.
* Add test code to run simulations using `outputs.nproc = 2` and an input catalog that exercises the code path that calls the `Vignetting.at_sky_coord` function.