### PR TITLE
Make doOpt=True work again.

### DIFF
--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -44,8 +44,8 @@ eval_variables:
     fexptime: { type: OpsimData, field: exptime }
 
     # Note: Another value we use in many eval items is det_name.  If using the LSST_CCD
-    #       output type, as we do here, it's added to the eval_variables automatically.
-    #       Otherwise you should set sdet_name here manually to e.g. R22_S11 or whatever.
+    #       output type, as we do here, it's automatically added as an availble eval variable.
+    #       Otherwise you should set sdet_name here manually to e.g. 'R22_S11' or whatever.
 
 
 # Any input data is set here.  These are read in at the start of the program and

--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -43,6 +43,10 @@ eval_variables:
 
     fexptime: { type: OpsimData, field: exptime }
 
+    # Note: Another value we use in many eval items is det_name.  If using the LSST_CCD
+    #       output type, as we do here, it's added to the eval_variables automatically.
+    #       Otherwise you should set sdet_name here manually to e.g. R22_S11 or whatever.
+
 
 # Any input data is set here.  These are read in at the start of the program and
 # potentially updated for each output file. Also includes things that need some
@@ -120,8 +124,7 @@ image:
                 # the main process for all of the (many) vert faint sources, which only shoot
                 # a small numer of photons.
 
-    xsize: "$xsize"
-    ysize: "$ysize"
+    det_name: "$det_name"
 
     bandpass: { type: RubinBandpass, band: "$band" }
 

--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -242,6 +242,7 @@ stamp:
                 theta: { type: OpsimData, field: HA }
         -
             type: RubinDiffractionOptics
+            det_name: "$det_name"
             boresight: "$boresight"
             camera: "@output.camera"
             altitude: $altitude

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -23,6 +23,7 @@ The *GalSim* config system is described in the `GalSim documentation <http://gal
 
         image:
             type: LSST_Image
+            det_name: $det_name
 
             sensor:
                 type: Silicon
@@ -256,6 +257,7 @@ Once the Rubin sky-model has been specified you can use the calculated sky level
 
     image:
         type: LSST_Image
+        det_name: $det_name
 
         sky_level: { type: SkyLevel }  # Computed from input.sky_model.
         apply_sky_gradient: True
@@ -365,6 +367,7 @@ Once the tree ring models have been read in, you can use them in other parts of 
 
     image:
         type: LSST_Image
+        det_name: $det_name
 
         sensor:
             type: Silicon
@@ -426,13 +429,13 @@ The ``LSST_Image`` type is a version of the *GalSim* "Scattered Image" image cla
 Required keywords to set:
 """""""""""""""""""""""""
 
-    * ``xsize`` = *int_value* The size of the image in the X direction (i.e. the number of columns)
-    * ``ysize`` = *int_value* The size of the image in the Y direction (i.e. the number of rows)
-
+    * ``det_name`` = *str_value* The name of the detector
 
 Optional keywords to set:
 """""""""""""""""""""""""
 
+    * ``xsize`` = *int_value* (default = the real xsize of the given detector) The size of the image in the X direction (i.e. the number of columns)
+    * ``ysize`` = *int_value* (default = the real ysize of the given detector) The size of the image in the Y direction (i.e. the number of rows)
     * ``dytpe`` = *str_value* (default = None) allows you to set numpy.dtype  for the underlying data in the image.
     *  ``apply_sky_gradient`` = *bool_value* (default = False) If True vary the sky background level linearly across the sensors to match the expected flux at the four corners of the at each sensor.
     * ``apply_fringing`` = *bool_value* (default = False) If True, apply a fringing pattern to the sky background level.  This is only currently possible for y band observations, so a recommended value for this parameters is ``$band == 'y'``.

--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -44,10 +44,10 @@ class LSST_CCDBuilder(OutputBuilder):
             det_name = only_dets[detnum]
         else:
             det_name = camera[detnum].getName()
-        base['det_name'] = det_name
         if 'eval_variables' not in base:
             base['eval_variables'] = {}
         base['eval_variables']['sdet_name'] = det_name
+        self.det_name = det_name
 
         if 'exptime' in config:
             base['exptime'] = galsim.config.ParseValue(
@@ -117,7 +117,6 @@ class LSST_CCDBuilder(OutputBuilder):
             logger.info('Adding cosmic rays with rate %f using %s.',
                         cosmic_ray_rate, cosmic_ray_catalog)
             exptime = base['exptime']
-            det_name = base['det_name']
             cosmic_rays = CosmicRays(cosmic_ray_rate, cosmic_ray_catalog)
             rng = galsim.config.GetRNG(config, base)
             cosmic_rays.paint(image.array, rng, exptime=exptime)
@@ -128,7 +127,7 @@ class LSST_CCDBuilder(OutputBuilder):
         image.header = galsim.FitsHeader()
         exptime = base['exptime']
         image.header['EXPTIME'] = exptime
-        image.header['DET_NAME'] = base['det_name']
+        image.header['DET_NAME'] = self.det_name
 
         header_vals = copy.deepcopy(params.get('header', {}))
         opsim_data = get_opsim_data(config, base)

--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -56,6 +56,12 @@ class LSST_CCDBuilder(OutputBuilder):
         else:
             base['exptime'] = 30.0
 
+        # Save the detector size, so the input catalogs can use it to figure out which
+        # objects will be visible.
+        det_bbox = camera[self.det_name].getBBox()
+        base['det_xsize'] = det_bbox.width
+        base['det_ysize'] = det_bbox.height
+
     def getNFiles(self, config, base, logger=None):
         """Returns the number of files to be built.
 

--- a/imsim/ccd.py
+++ b/imsim/ccd.py
@@ -10,11 +10,6 @@ from .camera import get_camera
 from .opsim_data import get_opsim_data
 
 
-# Add `xsize` and `ysize` to the list of preset variables. These are
-# evaluated below in LSST_CCDBuilder.setup.
-galsim.config.eval_base_variables.extend(('xsize', 'ysize'))
-
-
 class LSST_CCDBuilder(OutputBuilder):
     """This runs the overall generation of an LSST CCD file.
 
@@ -53,11 +48,6 @@ class LSST_CCDBuilder(OutputBuilder):
         if 'eval_variables' not in base:
             base['eval_variables'] = {}
         base['eval_variables']['sdet_name'] = det_name
-
-        # Get detector size in pixels.
-        det_bbox = camera[det_name].getBBox()
-        base['xsize'] = det_bbox.width
-        base['ysize'] = det_bbox.height
 
         if 'exptime' in config:
             base['exptime'] = galsim.config.ParseValue(

--- a/imsim/flat.py
+++ b/imsim/flat.py
@@ -156,7 +156,7 @@ class LSST_FlatBuilder(ImageBuilder):
 
         completed_sections = set()
         if self.checkpoint is not None:
-            chk_name = 'addNoise_%s' % (base.get('det_name', ''))
+            chk_name = 'addNoise_%s'%image_num
             # Read in any checkpoint data
             saved = self.checkpoint.load(chk_name)
             if saved is not None:

--- a/imsim/instcat.py
+++ b/imsim/instcat.py
@@ -528,8 +528,8 @@ class InstCatalogLoader(InputLoader):
         kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
         wcs = galsim.config.BuildWCS(base['image'], 'wcs', base, logger=logger)
         kwargs['wcs'] = wcs
-        kwargs['xsize'] = base.get('image_xsize', 4096)
-        kwargs['ysize'] = base.get('image_ysize', 4096)
+        kwargs['xsize'] = base.get('det_xsize', 4096)
+        kwargs['ysize'] = base.get('det_ysize', 4096)
         kwargs['logger'] = logger
         return kwargs, False
 

--- a/imsim/instcat.py
+++ b/imsim/instcat.py
@@ -528,8 +528,8 @@ class InstCatalogLoader(InputLoader):
         kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
         wcs = galsim.config.BuildWCS(base['image'], 'wcs', base, logger=logger)
         kwargs['wcs'] = wcs
-        kwargs['xsize'] = base['xsize']
-        kwargs['ysize'] = base['ysize']
+        kwargs['xsize'] = base.get('image_xsize', 4096)
+        kwargs['ysize'] = base.get('image_ysize', 4096)
         kwargs['logger'] = logger
         return kwargs, False
 

--- a/imsim/instcat.py
+++ b/imsim/instcat.py
@@ -462,7 +462,7 @@ def InstCatObj(config, base, ignore, gsparams, logger):
     index = kwargs['index']
 
     rng = galsim.config.GetRNG(config, base, logger, 'InstCatObj')
-    exptime = base.get('exptime',None)
+    exptime = base.get('exptime', 30)
 
     obj = inst.getObj(index, gsparams=gsparams, rng=rng, exptime=exptime)
     base['object_id'] = inst.getID(index)

--- a/imsim/photon_ops.py
+++ b/imsim/photon_ops.py
@@ -42,6 +42,7 @@ class RubinOptics(PhotonOp):
     _req_params = {
         "boresight": CelestialCoord,
         "camera": str,
+        "det_name": str,
     }
 
     def __init__(
@@ -155,6 +156,7 @@ class RubinDiffractionOptics(RubinOptics):
     _req_params = {
         "boresight": CelestialCoord,
         "camera": str,
+        "det_name": str,
         "altitude": Angle,
         "azimuth": Angle,
     }
@@ -359,7 +361,7 @@ def config_kwargs(config, base, cls, base_args=()):
     return kwargs
 
 
-_rubin_optics_base_args = ("sky_pos", "image_pos", "det_name")
+_rubin_optics_base_args = ("sky_pos", "image_pos")
 
 
 @photon_op_type("RubinOptics", input_type="telescope")

--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -218,8 +218,8 @@ class SkyCatalogLoader(InputLoader):
                                                   opt=opt)
         wcs = galsim.config.BuildWCS(base['image'], 'wcs', base, logger=logger)
         kwargs['wcs'] = wcs
-        kwargs['xsize'] = base.get('image_xsize', 4096)
-        kwargs['ysize'] = base.get('image_ysize', 4096)
+        kwargs['xsize'] = base.get('det_xsize', 4096)
+        kwargs['ysize'] = base.get('det_ysize', 4096)
         kwargs['logger'] = logger
 
         # Sky catalog object lists are created per CCD, so they are

--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -218,8 +218,8 @@ class SkyCatalogLoader(InputLoader):
                                                   opt=opt)
         wcs = galsim.config.BuildWCS(base['image'], 'wcs', base, logger=logger)
         kwargs['wcs'] = wcs
-        kwargs['xsize'] = base['xsize']
-        kwargs['ysize'] = base['ysize']
+        kwargs['xsize'] = base.get('image_xsize', 4096)
+        kwargs['ysize'] = base.get('image_ysize', 4096)
         kwargs['logger'] = logger
 
         # Sky catalog object lists are created per CCD, so they are

--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -263,7 +263,7 @@ def SkyCatObj(config, base, ignore, gsparams, logger):
     index = kwargs['index']
 
     rng = galsim.config.GetRNG(config, base, logger, 'SkyCatObj')
-    exptime = base.get('exptime', None)
+    exptime = base.get('exptime', 30)
 
     obj = skycat.getObj(index, gsparams=gsparams, rng=rng, exptime=exptime)
     base['object_id'] = skycat.objects[index].id

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -181,29 +181,28 @@ class LSST_SiliconBuilder(StampBuilder):
             # Start with GalSim's estimate of a good box size.
             image_size = obj.getGoodImageSize(self._pixel_scale)
 
-            # Find a postage stamp region to draw onto.  Use (sky noise)/8. as the nominal
-            # minimum surface brightness for rendering an extended object.
-            base['current_noise_image'] = base['current_image']
-            noise_var = galsim.config.CalculateNoiseVariance(base)
-            keep_sb_level = np.sqrt(noise_var)/8.
-            self._large_object_sb_level = 3*keep_sb_level
-
-            gal_at_eff_wl = gal.evaluateAtWavelength(bandpass.effective_wavelength)
             # For bright things, defined as having an average of at least 10 photons per
             # pixel on average, or objects for which GalSim's estimate of the image_size is larger
             # than self._Nmax, compute the image_size using the surface brightness limit, trying
             # to be careful about not truncating the surface brightness
             # at the edge of the box.
             if (self.realized_flux > 10 * image_size**2) or (image_size > self._Nmax):
-                image_size = self._getGoodPhotImageSize([gal_at_eff_wl, psf], keep_sb_level,
+                # Find a postage stamp region to draw onto.  Use (sky noise)/8. as the nominal
+                # minimum surface brightness for rendering an extended object.
+                base['current_noise_image'] = base['current_image']
+                noise_var = galsim.config.CalculateNoiseVariance(base)
+                keep_sb_level = np.sqrt(noise_var)/8.
+                self._large_object_sb_level = 3*keep_sb_level
+                image_size = self._getGoodPhotImageSize([gal_achrom, psf], keep_sb_level,
                                                         pixel_scale=self._pixel_scale)
 
-            # If the above size comes out really huge, scale back to what you get for
-            # a somewhat brighter surface brightness limit.
-            if image_size > self._Nmax:
-                image_size = self._getGoodPhotImageSize([gal_at_eff_wl, psf], self._large_object_sb_level,
-                                                        pixel_scale=self._pixel_scale)
-                image_size = min(image_size, self._Nmax)
+                # If the above size comes out really huge, scale back to what you get for
+                # a somewhat brighter surface brightness limit.
+                if image_size > self._Nmax:
+                    image_size = self._getGoodPhotImageSize([gal_achrom, psf],
+                                                            self._large_object_sb_level,
+                                                            pixel_scale=self._pixel_scale)
+                    image_size = min(image_size, self._Nmax)
 
         logger.info('Object %d will use stamp size = %s',base.get('obj_num',0),image_size)
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -98,6 +98,7 @@ def test_checkpoint_image():
         },
         'image': {
             'type': 'LSST_Image',
+            'det_name': 'R22_S11',
             'xsize': 2048,
             'ysize': 2048,
             'wcs': wcs,
@@ -234,6 +235,7 @@ def test_checkpoint_flatten():
         },
         'image': {
             'type': 'LSST_Image',
+            'det_name': 'R22_S11',
             'xsize': 2048,
             'ysize': 2048,
             'pixel_scale': 0.2,

--- a/tests/test_diffraction_fft.py
+++ b/tests/test_diffraction_fft.py
@@ -109,8 +109,7 @@ def create_test_config(
         "wcs": wcs,
         "image": {
             "type": "LSST_Image",
-            "xsize": xsize,
-            "ysize": ysize,
+            "det_name": "R22_S11",
             "wcs": wcs,
             "random_seed": 12345,
             "nobjects": 1,

--- a/tests/test_diffraction_fft.py
+++ b/tests/test_diffraction_fft.py
@@ -73,6 +73,7 @@ def create_test_config(
     if enable_diffraction:
         optics_args = {
             "type": "RubinDiffractionOptics",
+            "det_name": "R22_S11",
             "disable_field_rotation": exptime == 0.0,
             **alt_az,
         }

--- a/tests/test_fringing.py
+++ b/tests/test_fringing.py
@@ -33,6 +33,7 @@ def test_fringing():
             'ysize': 4004,
             'wcs': wcs,
             'nobjects': 0,
+            'det_name': 'R22_S11',
         },
     }
 
@@ -70,7 +71,8 @@ def test_fringing():
             'nobjects': 0,
             'sky_level_pixel': sky_level,
             'apply_fringing': True,
-            'boresight': world_center
+            'boresight': world_center,
+            'det_name': 'R22_S11',
         },
         'det_name': 'R22_S11'
     }

--- a/tests/test_photon_ops.py
+++ b/tests/test_photon_ops.py
@@ -423,7 +423,6 @@ TEST_BASE_CONFIG = {
             "rotTelPos": np.pi / 3 * galsim.radians,
         }
     },
-    "det_name": "R22_S11",
     "output": {"camera": "LsstCam"},
     "_icrf_to_field": create_test_icrf_to_field(
         galsim.CelestialCoord(
@@ -505,6 +504,7 @@ def test_config_rubin_diffraction_optics():
             "photon_ops": [
                 {
                     "type": "RubinDiffractionOptics",
+                    "det_name": "R22_S11",
                     "camera": "LsstCam",
                     "boresight": {
                         "type": "RADec",
@@ -542,6 +542,7 @@ def test_config_rubin_diffraction_optics_without_field_rotation():
             "photon_ops": [
                 {
                     "type": "RubinDiffractionOptics",
+                    "det_name": "R22_S11",
                     "camera": "LsstCam",
                     "boresight": {
                         "type": "RADec",
@@ -581,6 +582,7 @@ def test_config_rubin_optics():
                 {
                     "type": "RubinOptics",
                     "camera": "LsstCam",
+                    "det_name": "R22_S11",
                     "boresight": {
                         "type": "RADec",
                         "ra": "1.1047934165124105 radians",
@@ -633,7 +635,8 @@ def test_double_optics_warning():
         **deepcopy(TEST_BASE_CONFIG),
         'stamp': {
             'photon_ops': [
-                {'type': 'RubinOptics',}
+                {'type': 'RubinOptics', 'det_name': 'R22_S11'}
+
             ]
         },
         'image': {
@@ -665,6 +668,7 @@ def test_phase_affects_image():
                 {
                     "type": "RubinOptics",
                     "camera": "LsstCam",
+                    "det_name": "R22_S11",
                     "boresight": {
                         "type": "RADec",
                         "ra": "1.1047934165124105 radians",

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -453,5 +453,67 @@ class PsfTestCase(unittest.TestCase):
         np.testing.assert_allclose(ref_img.array, img.array, rtol=0.15, atol=50)
 
 
+def test_doopt_true():
+    """Check that doOpt=True works properly.
+    """
+    config = {
+        'input': {
+            'telescope': {
+                'file_name': 'LSST_r.yaml',
+                'rotTelPos': np.pi / 3 * galsim.radians,
+                'camera': 'LsstCam',
+            },
+            'atm_psf': {
+                'airmass': 1.1,
+                'rawSeeing':  0.6,
+                'band':  'r',
+                'boresight': galsim.CelestialCoord(0*galsim.degrees, 0*galsim.degrees),
+                'screen_size': 102.4,
+                'nproc': 1,
+                'doOpt': True,
+            }
+        },
+        'image': {
+            'type': 'LSST_Image',
+            'det_name': 'R22_S11',
+            'xsize': 256,
+            'ysize': 256,
+            'random_seed': 1234,
+            'nobjects': 1,
+            'pixel_scale': 0.2,
+            'bandpass': {'type': 'RubinBandpass', 'band': 'r'},
+            'noise': {'type': 'Poisson'},
+            'wcs': {
+                'type' : 'Tan',
+                'dudx' : 0.2,
+                'dudy' : 0.,
+                'dvdx' : 0.,
+                'dvdy' : 0.2,
+                'ra' : '0 deg',
+                'dec' : '0 deg',
+            }
+        },
+        'psf': {
+            'type': 'AtmosphericPSF',
+        },
+        'gal': {
+            'type': 'DeltaFunction',
+            'flux': 1000,
+            'sed': galsim.SED('vega.txt', 'nm', 'flambda'),
+        },
+        'stamp': {
+            'type': 'LSST_Silicon',
+            'image_pos': galsim.PositionD(100,100),
+        },
+        'output': {
+            'file_name': 'output/doopt.fits',
+        },
+    }
+    with CaptureLog() as cl:
+        galsim.config.Process(config, logger=cl.logger)
+    print(cl.output)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sky_model.py
+++ b/tests/test_sky_model.py
@@ -102,6 +102,7 @@ def test_sky_gradient():
         },
         'image': {
             'type': 'LSST_Image',
+            'det_name': 'R22_S11',
             'xsize': image_xsize,
             'ysize': image_xsize,
             'wcs': wcs,

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -88,7 +88,7 @@ def test_lsst_silicon_builder_passes_correct_photon_ops_to_drawImage() -> None:
     }
     for method, expected_specific_args, prof_type, op_type in (
         ("phot", expected_phot_args, 'galsim.ChromaticTransformation', imsim.RubinDiffractionOptics),
-        ("fft", expected_fft_args, 'galsim.ChromaticTransformation', imsim.RubinDiffraction),
+        ("fft", expected_fft_args, 'galsim.ChromaticConvolution', imsim.RubinDiffraction),
     ):
         # mock.patch basically wraps these functions so we can access how they were called
         # and what their return values were.
@@ -140,7 +140,7 @@ def test_stamp_builder_works_without_photon_ops_or_faint() -> None:
     }
     for method, expected_specific_args, photon_ops_key, prof_type in (
         ("phot", expected_phot_args, 'photon_ops', 'galsim.ChromaticTransformation'),
-        ("fft", expected_fft_args, 'fft_photon_ops', 'galsim.ChromaticTransformation'),
+        ("fft", expected_fft_args, 'fft_photon_ops', 'galsim.ChromaticConvolution'),
     ):
         for faint in [True, False]:
             use_config = galsim.config.CopyConfig(config)

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -1,190 +1,170 @@
-from unittest import mock, TestCase
+from unittest import mock
 import galsim
-from imsim import stamp
-from imsim.opsim_data import OpsimDataLoader
+import imsim
+from test_photon_ops import create_test_icrf_to_field
 
 METHOD_PHOT = "phot"
 METHOD_FFT = "fft"
 
 
-def create_test_config(methods):
+def create_test_config():
     config = {
         "input": {
             "telescope": {
                 "file_name": "LSST_r.yaml",
             }
         },
-        "_input_objs": {
-            "opsim_data": [
-                OpsimDataLoader.from_dict({"altitude": 43.0, "azimuth": 0.0})
-            ]
+        # Note: This _icrf_to_field thing means that all the RubinOptics, RubinDiffraction,
+        #       and RubinDiffractionOptics photon ops implicitly *require* the WCS be
+        #       a BatoidWCS.  This doesn't seem great, but I'm not fixing it now.
+        "_icrf_to_field": create_test_icrf_to_field(
+            galsim.CelestialCoord(
+                1.1047934165124105 * galsim.radians, -0.5261230452954583 * galsim.radians
+            ),
+            "R22_S11",
+        ),
+        "image_pos": galsim.PositionD(20,20),
+        "sky_pos": galsim.CelestialCoord(
+            1.1056660811384078 * galsim.radians, -0.5253441048502933 * galsim.radians
+        ),
+        "stamp": {
+            'type': 'LSST_Silicon',
+            'photon_ops': [{
+                "type": "RubinDiffractionOptics",
+                "altitude": 80 * galsim.degrees,
+                "azimuth": 0 * galsim.degrees,
+                "latitude": -30.24463 * galsim.degrees,
+                "boresight": galsim.CelestialCoord(0*galsim.degrees, 0*galsim.degrees),
+                "camera": 'LsstCam',
+                "det_name": 'R22_S11',
+            }],
+            'fft_photon_ops': [{
+                "type": "RubinDiffraction",
+                "altitude": 80 * galsim.degrees,
+                "azimuth": 0 * galsim.degrees,
+                "latitude": -30.24463 * galsim.degrees,
+            }],
         },
-        "sky_pos": {
-            "type": "RADec",
-            "ra": "1.1056660811384078 radians",
-            "dec": "-0.5253441048502933 radians",
-        },
-        "stamp": {},
-        "bandpass": mock.Mock(),
-        "wcs": mock.Mock(),
+        "bandpass": galsim.Bandpass('LSST_r.dat', wave_type='nm'),
+        "wcs": galsim.PixelScale(0.2),
     }
-    if METHOD_PHOT in methods:
-        config["stamp"]["photon_ops"] = [
-            {
-                "type": "lsst_diffraction",
-                "latitude": -30.24463,
-            }
-        ]
-    if METHOD_FFT in methods:
-        config["stamp"]["fft_photon_ops"] = [
-            {
-                "type": "lsst_diffraction",
-                "latitude": -30.24463,
-            }
-        ]
-
     galsim.config.ProcessInput(config)
+    galsim.config.SetupInputsForImage(config, None)
     return config
 
 
 def create_test_lsst_silicon(faint: bool):
-    lsst_silicon = stamp.LSST_SiliconBuilder()
+    lsst_silicon = imsim.LSST_SiliconBuilder()
     lsst_silicon.realized_flux = 100 if not faint else 99
-    lsst_silicon.rng = mock.Mock()
-    lsst_silicon.diffraction_fft = mock.Mock()
+    lsst_silicon.rng = galsim.BaseDeviate(1234)
+    lsst_silicon.diffraction_fft = None
     return lsst_silicon
-
-
-def create_test_image():
-    image_copy = mock.MagicMock(
-        __iadd__=mock.Mock(), array=mock.MagicMock(__lt__=mock.Mock())
-    )
-    image = mock.Mock(copy=mock.Mock(return_value=image_copy))
-    return image
-
-
-def create_test_prof():
-    prof = mock.MagicMock(withFlux=mock.Mock())
-    prof.evaluateAtWavelength = mock.Mock(return_value=prof)
-    prof.__mul__ = mock.Mock(return_value=prof)
-    return prof
 
 
 def test_lsst_silicon_builder_passes_correct_photon_ops_to_drawImage() -> None:
     """LSST_SiliconBuilder.draw passes the correct list of photon_ops
     to prof.drawImage."""
     lsst_silicon = create_test_lsst_silicon(faint=False)
-    image = create_test_image()
-    image_copy = image.copy.return_value
-    offset = mock.Mock()
-    logger = mock.Mock(info=mock.Mock())
-    built_photon_ops = mock.Mock()
+    image = galsim.Image(ncol=256, nrow=256)
+    offset = galsim.PositionD(0,0)
+    config = create_test_config()
+    prof = galsim.Gaussian(sigma=2) * galsim.SED('vega.txt', 'nm', 'flambda')
+    logger = galsim.config.LoggerWrapper(None)
+
     expected_phot_args = {
-        "maxN": mock.ANY,
-        "n_photons": mock.ANY,
-        "add_to_image": True,
-        "poisson_flux": False,
+        "rng": lsst_silicon.rng,
+        "maxN": int(1e6),
+        "n_photons": lsst_silicon.realized_flux,
         "image": image,
         "sensor": None,
+        "add_to_image": True,
+        "poisson_flux": False,
     }
-    expected_fft_args = {"n_subsample": 1, "image": image_copy, "maxN": mock.ANY}
-    for method, expected_specific_args in (
-        ("phot", expected_phot_args),
-        ("fft", expected_fft_args),
+    expected_fft_args = {
+        "maxN": int(1e6),
+        "rng": lsst_silicon.rng,
+        "n_subsample": 1,
+        "image": mock.ANY,  # For fft, the image gets modified from the original
+    }
+    for method, expected_specific_args, prof_type, op_type in (
+        ("phot", expected_phot_args, 'galsim.ChromaticTransformation', imsim.RubinDiffractionOptics),
+        ("fft", expected_fft_args, 'galsim.ChromaticTransformation', imsim.RubinDiffraction),
     ):
-        config = create_test_config(methods={method})
-        mock_build_photon_ops = mock.Mock(return_value=built_photon_ops)
-        prof = create_test_prof()
-        with TestCase().subTest(method=method):
-            with mock.patch(
-                "galsim.config.BuildPhotonOps", mock_build_photon_ops
-            ), mock.patch("galsim.PoissonNoise"):
+        # mock.patch basically wraps these functions so we can access how they were called
+        # and what their return values were.
+        with mock.patch(prof_type+'.drawImage') as mock_drawImage:
+            lsst_silicon.draw(
+                prof,
+                image,
+                method,
+                offset,
+                config=config["stamp"],
+                base=config,
+                logger=logger,
+            )
+            mock_drawImage.assert_called_once_with(
+                config['bandpass'],
+                method=method,
+                offset=offset,
+                wcs=config['wcs'],
+                photon_ops=mock.ANY,  # Check the items in this below.
+                **expected_specific_args
+            )
+            called_photon_ops = mock_drawImage.call_args.kwargs['photon_ops']
+            assert len(called_photon_ops) == 1
+            assert type(called_photon_ops[0]) == op_type
+
+def test_stamp_builder_works_without_photon_ops_or_faint() -> None:
+    """Here, we test that if LSST_SiliconBuilder.drawImage passes empty photon_ops,
+    when faint is True or photon ops for the used method are empty.
+    """
+
+    image = galsim.Image(ncol=256, nrow=256)
+    offset = galsim.PositionD(0,0)
+    config = create_test_config()
+    prof = galsim.Gaussian(sigma=2) * galsim.SED('vega.txt', 'nm', 'flambda')
+    logger = galsim.config.LoggerWrapper(None)
+
+    expected_phot_args = {
+        "rng": mock.ANY,
+        "maxN": int(1e6),
+        "n_photons": None,  # Rewrite this below.
+        "image": image,
+        "sensor": None,
+        "photon_ops": [],
+        "add_to_image": True,
+        "poisson_flux": False,
+    }
+    expected_fft_args = {
+        "image": mock.ANY
+    }
+    for method, expected_specific_args, photon_ops_key, prof_type in (
+        ("phot", expected_phot_args, 'photon_ops', 'galsim.ChromaticTransformation'),
+        ("fft", expected_fft_args, 'fft_photon_ops', 'galsim.ChromaticTransformation'),
+    ):
+        for faint in [True, False]:
+            use_config = galsim.config.CopyConfig(config)
+            lsst_silicon = create_test_lsst_silicon(faint=faint)
+            if not faint:
+                # When not faint, check that photon_ops ends up empty when none are listed in
+                # the config (and there are no PSFs).
+                del use_config['stamp'][photon_ops_key]
+            expected_phot_args['n_photons'] = lsst_silicon.realized_flux
+
+            with mock.patch(prof_type+'.drawImage') as mock_drawImage:
                 lsst_silicon.draw(
                     prof,
                     image,
                     method,
                     offset,
-                    config=config["stamp"],
-                    base=config,
+                    config=use_config["stamp"],
+                    base=use_config,
                     logger=logger,
                 )
-            modified_prof = prof.withFlux.return_value
-            modified_prof.drawImage.assert_called_once_with(
-                mock.ANY,
-                method=method,
-                offset=offset,
-                wcs=mock.ANY,
-                photon_ops=built_photon_ops,
-                rng=lsst_silicon.rng,
-                **expected_specific_args
-            )
-            expected_photon_ops_config_field = {
-                "phot": "photon_ops",
-                "fft": "fft_photon_ops",
-            }
-            mock_build_photon_ops.assert_called_once_with(
-                config["stamp"],
-                expected_photon_ops_config_field[method],
-                config,
-                logger,
-            )
-
-
-def test_stamp_builder_works_without_photon_ops_or_faint() -> None:
-    """Here, we test that if LSST_SiliconBuilder.drawImage passes empty photon_ops,
-    when faint is True or photon ops for the used method are empty."""
-
-    image = create_test_image()
-    image_copy = image.copy.return_value
-    offset = mock.Mock()
-    logger = mock.Mock(info=mock.Mock())
-    expected_phot_args = {
-        "maxN": mock.ANY,
-        "n_photons": mock.ANY,
-        "add_to_image": True,
-        "poisson_flux": False,
-        "image": image,
-        "sensor": None,
-        "photon_ops": [],
-        "rng": mock.ANY,
-    }
-    expected_fft_args = {"image": image_copy}
-    for method, expected_specific_args in (
-        ("phot", expected_phot_args),
-        ("fft", expected_fft_args),
-    ):
-        for provided_photon_op_configs in (
-            {METHOD_PHOT, METHOD_FFT},
-            {METHOD_PHOT, METHOD_FFT} - {method},
-            (),
-        ):
-            config = create_test_config(methods=provided_photon_op_configs)
-            for faint in (True, False):
-                if not faint and method in provided_photon_op_configs:
-                    # This is neither faint nor is the photon_ops list for the used method empty.
-                    # => Dont want to test this case here.
-                    continue
-                lsst_silicon = create_test_lsst_silicon(faint=faint)
-                prof = create_test_prof()
-                with TestCase().subTest(
+                mock_drawImage.assert_called_once_with(
+                    config['bandpass'],
                     method=method,
-                    provided_photon_op_configs=provided_photon_op_configs,
-                    faint=faint,
-                ):
-                    with mock.patch("galsim.PoissonNoise"):
-                        lsst_silicon.draw(
-                            prof,
-                            image,
-                            method,
-                            offset,
-                            config=config["stamp"],
-                            base=config,
-                            logger=logger,
-                        )
-                    prof.withFlux.return_value.drawImage.assert_called_once_with(
-                        mock.ANY,
-                        method=method,
-                        offset=offset,
-                        wcs=mock.ANY,
-                        **expected_specific_args
-                    )
+                    offset=offset,
+                    wcs=config['wcs'],
+                    **expected_specific_args
+                )


### PR DESCRIPTION
The option to use a regular optical screen rather than the full batoid optics got broken during the changes in #380.  The problem is that there is a bug in GalSim (which we'll try to fix before 2.5, but has been a bug in the 2.4 series) where convolutions of 2 or more PhaseScreenPSFs don't work with photon shooting.  They each separately populate the pupil angles and then there is an error during convolution of the photon arrays, since that looks like an error.

Anyway, the psfs do work correctly if they are put in the photon_ops list, rather than being convolved with the galaxy.  This does almost the same thing, but the code path is a little different, so it avoids repopulating the pupil angles on the second PhaseScreenPSF.

Along the way, I fixed a few other things:
1. I discovered that LSST_Image didn't work when not using an LSST_CCD output type.  So I fixed that.  Mostly by having it figure out the image size itself and having the det_name value be explicit rather than just looking for it in base['det_name'].
2. A couple other classes had similar implicit dependence on LSST_CCD by looking for base['det_name'], so I fixed them the same way.
3. There were also some places that used xsize, ysize and expnum in base, which are set by LSST_CCD.  Those all have reasonable defaults, so I use the defaults now if they aren't set in base, but use the values if LSST_CCD has set them.
4. I removed most of the mocking that was in the tests in test_stamp.py, since they broke fairly catastrophically with the relatively minor changes I made to the draw function.  What's left might still be fragile to future code changes, but I think much less so than it was.  It's closer now to a regular integration test where the only thing mocked is the drawImage function so we can check the arguments it's getting.