### PR TITLE
Fix flux treatment of FFT renders to not double the Poisson noise

### DIFF
--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -337,5 +337,9 @@ output:
             dec: "$sky_pos.dec.deg"
             x: "$image_pos.x"
             y: "$image_pos.y"
-            realized_flux: "@realized_flux"
-            # TODO: ... more probably
+
+            # Note: these next 4 will only work if using the LSST_Silicon stamp type.
+            nominal_flux: "@nominal_flux"  # The nominal "expectation value" flux.
+            phot_flux: "@phot_flux"  # The realized flux for photon shooting.
+            fft_flux: "@fft_flux"  # If FFT rendering, then the flux used, including vignetting.
+            realized_flux: "@realized_flux"  # The actual flux that was added to the image.

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -456,6 +456,7 @@ class LSST_SiliconBuilder(StampBuilder):
             else:
                 self.fft_flux = self.nominal_flux
             base['fft_flux'] = self.fft_flux
+            base['phot_flux'] = 0.  # Indicates that photon shooting wasn't done.
 
             logger.info('Yes. Use FFT for object %d.  max_sb = %.0f > %.0f',
                         base.get('obj_num'), max_sb, fft_sb_thresh)

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -126,16 +126,17 @@ class LSST_SiliconBuilder(StampBuilder):
         self.nominal_flux = gal.flux
 
         # For photon shooting rendering, precompute the realization of the Poisson variate.
-        # Mostly so we can possibly abort early if realized_flux=0.
-        self.realized_flux = galsim.PoissonDeviate(self.rng, mean=gal.flux)()
+        # Mostly so we can possibly abort early if phot_flux=0.
+        self.phot_flux = galsim.PoissonDeviate(self.rng, mean=gal.flux)()
 
         # Save these later, in case needed for the output catalog.
         base['nominal_flux'] = self.nominal_flux
-        base['realized_flux'] = self.realized_flux
+        base['phot_flux'] = self.phot_flux
         base['fft_flux'] = 0.  # For fft drawing, this will be updated in buildPSF.
+        base['realized_flux'] = 0.  # Will update this after drawImage using im.added_flux
 
-        # Check if the realized flux is 0.
-        if self.realized_flux == 0:
+        # Check if the Poisson draw for the photon flux is 0.
+        if self.phot_flux == 0:
             # If so, we'll skip everything after this.
             # The mechanism within GalSim to do this is to raise a special SkipThisObject class.
             raise galsim.config.SkipThisObject('realized flux=0')
@@ -678,7 +679,7 @@ class LSST_SiliconBuilder(StampBuilder):
             # Go back to a combined convolution for fft drawing.
             prof = galsim.Convolve([gal] + psfs)
             try:
-                prof.drawImage(bandpass, **kwargs)
+                fft_image = prof.drawImage(bandpass, **kwargs)
             except galsim.errors.GalSimFFTSizeError as e:
                 # I think this shouldn't happen with the updates I made to how the image size
                 # is calculated, even for extremely bright things.  So it should be ok to
@@ -699,11 +700,12 @@ class LSST_SiliconBuilder(StampBuilder):
             fft_image.addNoise(galsim.PoissonNoise(rng=self.rng))
             # In case we had to make a bigger image, just copy the part we need.
             image += fft_image[image.bounds]
+            base['realized_flux'] = fft_image.added_flux
 
         else:
             # For photon shooting, use the poisson-realization of the flux
             # and tell GalSim not to redo the Poisson realization.
-            gal = gal.withFlux(self.realized_flux, bandpass)
+            gal = gal.withFlux(self.phot_flux, bandpass)
 
             if not faint and 'photon_ops' in config:
                 photon_ops = galsim.config.BuildPhotonOps(config, 'photon_ops', base, logger)
@@ -721,17 +723,18 @@ class LSST_SiliconBuilder(StampBuilder):
                 if sensor is not None:
                     sensor.updateRNG(self.rng)
 
-            gal.drawImage(bandpass,
-                          method='phot',
-                          offset=offset,
-                          rng=self.rng,
-                          maxN=maxN,
-                          n_photons=self.realized_flux,
-                          image=image,
-                          sensor=sensor,
-                          photon_ops=photon_ops,
-                          add_to_image=True,
-                          poisson_flux=False)
+            image = gal.drawImage(bandpass,
+                                  method='phot',
+                                  offset=offset,
+                                  rng=self.rng,
+                                  maxN=maxN,
+                                  n_photons=self.phot_flux,
+                                  image=image,
+                                  sensor=sensor,
+                                  photon_ops=photon_ops,
+                                  add_to_image=True,
+                                  poisson_flux=False)
+            base['realized_flux'] = image.added_flux
 
         return image
 

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -123,7 +123,16 @@ class LSST_SiliconBuilder(StampBuilder):
             # In this case, the object flux has not been precomputed
             # or cached by the skyCatalogs code.
             gal.flux = gal.calculateFlux(bandpass)
+        self.nominal_flux = gal.flux
+
+        # For photon shooting rendering, precompute the realization of the Poisson variate.
+        # Mostly so we can possibly abort early if realized_flux=0.
         self.realized_flux = galsim.PoissonDeviate(self.rng, mean=gal.flux)()
+
+        # Save these later, in case needed for the output catalog.
+        base['nominal_flux'] = self.nominal_flux
+        base['realized_flux'] = self.realized_flux
+        base['fft_flux'] = 0.  # For fft drawing, this will be updated in buildPSF.
 
         # Check if the realized flux is 0.
         if self.realized_flux == 0:
@@ -135,7 +144,7 @@ class LSST_SiliconBuilder(StampBuilder):
         if xsize > 0 and ysize > 0:
             pass  # Already set.
 
-        elif self.realized_flux < self._tiny_flux:
+        elif self.nominal_flux < self._tiny_flux:
             # For really faint things, don't try too hard.  Just use 32x32.
             xsize = ysize = 32
 
@@ -153,7 +162,7 @@ class LSST_SiliconBuilder(StampBuilder):
                 # evaluate than an AtmosphericPSF.
                 base['current_noise_image'] = base['current_image']
                 noise_var = galsim.config.CalculateNoiseVariance(base)
-                folding_threshold = noise_var/self.realized_flux
+                folding_threshold = noise_var/self.nominal_flux
                 if folding_threshold >= self._ft_default or folding_threshold == 0:
                     # a) Don't gratuitously raise folding_threshold above the normal default.
                     # b) If sky_level = 0, then folding_threshold=0.  This is bad (stepk=0 below),
@@ -166,7 +175,7 @@ class LSST_SiliconBuilder(StampBuilder):
                     # minimize how many of these we need to do.
                     folding_threshold = np.exp(np.floor(np.log(folding_threshold)))
                     logger.debug('Using folding_threshold %s',folding_threshold)
-                    logger.debug('From: noise_var = %s, flux = %s',noise_var,self.realized_flux)
+                    logger.debug('From: noise_var = %s, flux = %s',noise_var,self.nominal_flux)
                     gsparams = galsim.GSParams(folding_threshold=folding_threshold)
 
                 # Grab the three parameters we need for Kolmogorov_and_Gaussian_PSF.
@@ -183,7 +192,7 @@ class LSST_SiliconBuilder(StampBuilder):
                 psf = self.DoubleGaussian()
                 # For Chromatic objects, need to evaluate at the
                 # effective wavelength of the bandpass.
-                obj = galsim.Convolve(gal_achrom, psf).withFlux(self.realized_flux)
+                obj = galsim.Convolve(gal_achrom, psf).withFlux(self.nominal_flux)
 
                 # Start with GalSim's estimate of a good box size.
                 image_size = obj.getGoodImageSize(self._pixel_scale)
@@ -193,7 +202,7 @@ class LSST_SiliconBuilder(StampBuilder):
                 # than self._Nmax, compute the image_size using the surface brightness limit, trying
                 # to be careful about not truncating the surface brightness
                 # at the edge of the box.
-                if (self.realized_flux > 10 * image_size**2) or (image_size > self._Nmax):
+                if (self.nominal_flux > 10 * image_size**2) or (image_size > self._Nmax):
                     # Find a postage stamp region to draw onto.  Use (sky noise)/8. as the nominal
                     # minimum surface brightness for rendering an extended object.
                     base['current_noise_image'] = base['current_image']
@@ -411,8 +420,7 @@ class LSST_SiliconBuilder(StampBuilder):
         else:
             fft_sb_thresh = 0.
 
-        base['realized_flux'] = self.realized_flux
-        if self.realized_flux < 1.e6 or not fft_sb_thresh or self.realized_flux < fft_sb_thresh:
+        if self.nominal_flux < 1.e6 or not fft_sb_thresh or self.nominal_flux < fft_sb_thresh:
             self.use_fft = False
             return psf
 
@@ -420,7 +428,7 @@ class LSST_SiliconBuilder(StampBuilder):
         bandpass = base['bandpass']
         fft_psf = self.make_fft_psf(psf.evaluateAtWavelength(bandpass.effective_wavelength), logger)
         logger.info('Object %d has flux = %s.  Check if we should switch to FFT',
-                    base['obj_num'], self.realized_flux)
+                    base['obj_num'], self.nominal_flux)
 
         # Now this object should have a much better estimate of the real maximum surface brightness
         # than the original psf did.
@@ -430,7 +438,7 @@ class LSST_SiliconBuilder(StampBuilder):
         # Also note that `max_sb` is in photons/arcsec^2, so multiply by pixel_scale**2
         # to get photons/pixel, which we compare to fft_sb_thresh.
         gal_achrom = self.gal.evaluateAtWavelength(bandpass.effective_wavelength)
-        fft_obj = galsim.Convolve(gal_achrom, fft_psf).withFlux(self.realized_flux)
+        fft_obj = galsim.Convolve(gal_achrom, fft_psf).withFlux(self.nominal_flux)
         max_sb = fft_obj.max_sb/2. * self._pixel_scale**2
         logger.debug('max_sb = %s. cf. %s',max_sb,fft_sb_thresh)
         if max_sb > fft_sb_thresh:
@@ -438,13 +446,15 @@ class LSST_SiliconBuilder(StampBuilder):
             # For FFT-rendered objects, the telescope vignetting isn't
             # emergent as it is for the ray-traced objects, so use the
             # empirical vignetting function, if it's available, to
-            # scale the realized flux.
+            # scale the flux to use in FFTs.
             if self.vignetting is not None:
                 pix_to_fp = self.det.getTransform(cameraGeom.PIXELS,
                                                   cameraGeom.FOCAL_PLANE)
-                vignetted_flux = self.realized_flux*self.vignetting.at_sky_coord(
+                self.fft_flux = self.nominal_flux*self.vignetting.at_sky_coord(
                     base['sky_pos'], self.image.wcs, pix_to_fp)
-                self.realized_flux = round(vignetted_flux)
+            else:
+                self.fft_flux = self.nominal_flux
+            base['fft_flux'] = self.fft_flux
 
             logger.info('Yes. Use FFT for object %d.  max_sb = %.0f > %.0f',
                         base.get('obj_num'), max_sb, fft_sb_thresh)
@@ -622,10 +632,10 @@ class LSST_SiliconBuilder(StampBuilder):
         gal, *psfs = prof.obj_list if hasattr(prof,'obj_list') else [prof]
 
         max_flux_simple = config.get('max_flux_simple', 100)
-        faint = self.realized_flux < max_flux_simple
+        faint = self.nominal_flux < max_flux_simple
         bandpass = base['bandpass']
         if faint:
-            logger.info("Flux = %.0f  Using trivial sed", self.realized_flux)
+            logger.info("Flux = %.0f  Using trivial sed", self.nominal_flux)
             gal = gal.evaluateAtWavelength(bandpass.effective_wavelength)
             gal = gal * self._trivial_sed
         else:

--- a/imsim/stamp.py
+++ b/imsim/stamp.py
@@ -139,7 +139,7 @@ class LSST_SiliconBuilder(StampBuilder):
         if self.phot_flux == 0:
             # If so, we'll skip everything after this.
             # The mechanism within GalSim to do this is to raise a special SkipThisObject class.
-            raise galsim.config.SkipThisObject('realized flux=0')
+            raise galsim.config.SkipThisObject('phot_flux=0')
 
         # Otherwise figure out the stamp size
         if xsize > 0 and ysize > 0:

--- a/tests/test_process_info.py
+++ b/tests/test_process_info.py
@@ -43,6 +43,7 @@ class ProcessInfoTestCase(unittest.TestCase):
                        'image.sky_level': 0,
                        'image.random_seed': 42,
                        'image.sensor': '',
+                       'stamp.diffraction_fft': '',
                        'stamp.fft_sb_thresh': '1e5',
                        'stamp.size': 48,
                        'psf.items': '',

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -60,8 +60,8 @@ def create_test_config():
 
 def create_test_lsst_silicon(faint: bool):
     lsst_silicon = imsim.LSST_SiliconBuilder()
-    lsst_silicon.realized_flux = 100 if not faint else 99
-    lsst_silicon.nominal_flux = lsst_silicon.realized_flux
+    lsst_silicon.nominal_flux = 100 if not faint else 10
+    lsst_silicon.phot_flux = lsst_silicon.nominal_flux
     lsst_silicon.fft_flux = lsst_silicon.nominal_flux
     lsst_silicon.rng = galsim.BaseDeviate(1234)
     lsst_silicon.diffraction_fft = None
@@ -81,7 +81,7 @@ def test_lsst_silicon_builder_passes_correct_photon_ops_to_drawImage() -> None:
     expected_phot_args = {
         "rng": lsst_silicon.rng,
         "maxN": int(1e6),
-        "n_photons": lsst_silicon.realized_flux,
+        "n_photons": lsst_silicon.phot_flux,
         "image": image,
         "sensor": None,
         "add_to_image": True,
@@ -104,7 +104,8 @@ def test_lsst_silicon_builder_passes_correct_photon_ops_to_drawImage() -> None:
     ):
         # mock.patch basically wraps these functions so we can access how they were called
         # and what their return values were.
-        with mock.patch(prof_type+'.drawImage') as mock_drawImage:
+        image.added_flux = lsst_silicon.phot_flux
+        with mock.patch(prof_type+'.drawImage', return_value=image) as mock_drawImage:
             lsst_silicon.draw(
                 prof,
                 image,
@@ -164,9 +165,10 @@ def test_stamp_builder_works_without_photon_ops_or_faint() -> None:
                 # When not faint, check that photon_ops ends up empty when none are listed in
                 # the config (and there are no PSFs).
                 del use_config['stamp'][photon_ops_key]
-            expected_phot_args['n_photons'] = lsst_silicon.realized_flux
+            expected_phot_args['n_photons'] = lsst_silicon.phot_flux
 
-            with mock.patch(prof_type+'.drawImage') as mock_drawImage:
+            image.added_flux = lsst_silicon.phot_flux
+            with mock.patch(prof_type+'.drawImage', return_value=image) as mock_drawImage:
                 lsst_silicon.draw(
                     prof,
                     image,

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -61,6 +61,8 @@ def create_test_config():
 def create_test_lsst_silicon(faint: bool):
     lsst_silicon = imsim.LSST_SiliconBuilder()
     lsst_silicon.realized_flux = 100 if not faint else 99
+    lsst_silicon.nominal_flux = lsst_silicon.realized_flux
+    lsst_silicon.fft_flux = lsst_silicon.nominal_flux
     lsst_silicon.rng = galsim.BaseDeviate(1234)
     lsst_silicon.diffraction_fft = None
     return lsst_silicon


### PR DESCRIPTION
cf. Issue #419 

1. Switch to using the nominal flux for FFT renders, since we then add Poisson noise to the stamp image, which already does the work of Poisson-ifying the realized flux.
2. Switch the flux value used for all decisions (phot vs fft, faint vs not) to use the nominal flux, rather than the realized flux.
3. Changed the meaning of realized flux in the output file to be the actual number of photons that landed on the image, rather than the number of photons shot.  This way vignetting is consistently included in this definition regardless of whether the object used phot or fft.
4. Added phot_flux and fft_flux values in the output file.  Only one of these is non-zero, and it is the flux used for each rendering type.  So phot_flux is what used to be called realized_flux for photon shooting.  And fft_flux is what used to be called realized_flux for fft renders.  These each have slightly different meanings, but they are well-defined for each method.
5. Added tests of all these flux values in the output catalog.