### PR TITLE
Parse LSSTBuilder args using config machinery

### DIFF
--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -260,9 +260,9 @@ def _parse_fea(config, base, logger):
 
     perturbations = {}
 
-    skip = list(req.keys()) + list(opt.keys()) + list(single.keys()) + ['_get']
+    skip = list(req.keys()) + list(opt.keys()) + list(single.keys())
     for k, v in config.items():
-        if k in skip:
+        if k in skip or k[0] == '_':
             continue
         method = getattr(LSSTBuilder, "with_"+k)
         req = getattr(method, "_req_params", {})


### PR DESCRIPTION
I added a couple new arguments to the batoid_rubin:LSSTBuilder constructor.  They didn't get picked up by ImSim config though, and in fact, I don't think the previously `bend_dir` and `fea_dir` were getting picked up either.  So this PR adds galsim config processing for the LSSTBuilder arguments.  

This will depend on a not-yet-pushed branch in batoid_rubin, so I don't expect CI to pass yet.  But I'm hopeful I'll be able to merge the batoid_rubin stuff tonight or tomorrow.  Just wanted to stake this PR now before any new versions are tagged.