### PR TITLE
Import LSSTBuilder at file scope

### DIFF
--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -1,3 +1,4 @@
+from batoid_rubin import LSSTBuilder
 from galsim.config import (
     InputLoader, RegisterInputType, GetAllParams, get_cls_params, ParseValue,
     LoggerWrapper, GetCurrentValue
@@ -104,8 +105,6 @@ def apply_fea(
     float.  Future additions to the `batoid_rubin` package may include new or
     changed APIs to the examples above.
     """
-    from batoid_rubin import LSSTBuilder
-
     builder = LSSTBuilder(telescope, **kwargs)
     for k, v in fea_perturbations.items():
         method = getattr(builder, "with_"+k)
@@ -246,8 +245,6 @@ def load_telescope(
 
 
 def _parse_fea(config, base, logger):
-    from batoid_rubin import LSSTBuilder
-
     req, opt, single, takes_rng = get_cls_params(LSSTBuilder)
     LSSTBuilder_kwargs, safe = GetAllParams(
         config,


### PR DESCRIPTION
While trying to run ImSim with multiprocessing (on ARM MacOS) as part of the AOS ts_imsim, I encountered the error:
```
objc[26896]: +[NSCheapMutableString initialize] may have been in progress in another thread when fork() was called.
objc[26896]: +[NSCheapMutableString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```

I tracked the origin of this error to a `from batoid_rubin import LSSTBuilder` statement within telescope_loader.py.  On a whim, I decided to try moving the import to file-level instead of function-level, and that actually seems to solve things.  Must be something about having the parent process doing the import and then forking vs forking first and importing in each subprocess?  So not entirely sure what's going on, but the change here feels pretty minor and does seem to work.