### PR TITLE
Add support for ComCam

### DIFF
--- a/imsim/telescope_loader.py
+++ b/imsim/telescope_loader.py
@@ -371,7 +371,13 @@ class DetectorTelescope:
         logger=None
     ):
         # Batoid has a different name for LsstCam than DM code.  So we need to switch it here.
-        cameraName = 'LSSTCamera' if camera == 'LsstCam' else camera
+        match camera:
+            case 'LsstCam':
+                cameraName = 'LSSTCamera'
+            case 'LsstComCam':
+                cameraName = 'ComCam'
+            case _:
+                cameraName = camera
         self.fiducial = load_telescope(
             telescope=file_name,
             perturbations=perturbations,


### PR DESCRIPTION
Adds support for ComCam.

Note, possibly only works on `main` branches of `batoid` and `batoid_rubin` at the moment.  I had a bug in my ComCam optics yaml where both the camera and the camera+telescope were named `ComCam`.  This collision meant when you tried to rotate the camera, you ended up rotating the entire telescope instead.  Will be fixed in a point release soonish...