### PR TITLE
stamp handling and config tweaks

### DIFF
--- a/config/imsim-config-skycat.yaml
+++ b/config/imsim-config-skycat.yaml
@@ -23,7 +23,7 @@ template: imsim-config
 
 input.sky_catalog:
     file_name: default_sky_cat.yaml
-    band: { type: OpsimData, field: band }
+    band: $band
     mjd: { type: OpsimData, field: mjd }
 
 input.opsim_data:

--- a/config/imsim-config.yaml
+++ b/config/imsim-config.yaml
@@ -104,9 +104,10 @@ input:
         dir: checkpoint
         file_name:
           type: FormattedStr
-          format : checkpoint_%08d-%s.hdf
+          format : checkpoint_%08d-%s-%s.hdf
           items:
               - { type: OpsimData, field: observationId }
+              - "$band"
               - "$det_name"
 
     vignetting:


### PR DESCRIPTION
* ~The original issue the stamp handling changes are meant to address were addressed in [GalSim #1258](https://github.com/GalSim-developers/GalSim/pull/1258), but they seem useful to keep regardless.~
* Chris added some fixes to enable the skyCatalogs interface code to use the band set at the config level and to incorporate the band info in the checkpoint file names to enable simulating the same exposure in different bands.