### PR TITLE
Add ability to add keywords for the DM Butler directly into primary amp headers.

### DIFF
--- a/imsim/readout.py
+++ b/imsim/readout.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from astropy.io import fits
 from astropy.time import Time
 import galsim
-from galsim.config import ExtraOutputBuilder, RegisterExtraOutput, GetAllParams
+from galsim.config import ExtraOutputBuilder, RegisterExtraOutput, GetAllParams, ParseValue
 from lsst.afw import cameraGeom
 import lsst.obs.lsst
 from lsst.obs.lsst.translators.lsst import SIMONYI_TELESCOPE
@@ -556,11 +556,15 @@ class CameraReadout(ExtraOutputBuilder):
             'pcti': float,
             'full_well': float,
             'read_noise': float,
-            'bias_levels_file': str,
-            'added_keywords': dict
+            'bias_levels_file': str
             }
-        ignore = ['file_name', 'dir', 'hdu', 'filter']
+        ignore = ['file_name', 'dir', 'hdu', 'filter', 'added_keywords']
         kwargs = GetAllParams(config, base, opt=opt, ignore=ignore)[0]
+
+        if 'added_keywords' in config:
+            kwargs['added_keywords'] = {}
+            for k in (added_keywords := config.get('added_keywords', {})):
+                kwargs['added_keywords'][k], safe = ParseValue(added_keywords, k, base, str)
 
         ccd_readout = CcdReadout(main_data[0], logger, **kwargs)
 

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -37,6 +37,10 @@ class ImageSourceTestCase(unittest.TestCase):
                     'bias_level': 1000.,
                     'pcti': 1.e-6,
                     'scti': 1.e-6,
+                    'added_keywords' : {
+                        'TESTKEY1': 'TESTVAL1',
+                        'TESTKEY2': 'TESTVAL2'
+                    }
                 }
             },
             'index_key': 'image_num',
@@ -92,6 +96,9 @@ class ImageSourceTestCase(unittest.TestCase):
         self.readout.writeFile(outfile, self.readout_config, self.config, self.logger)
         with fits.open(outfile) as hdus:
             self.assertEqual(hdus[0].header['IMSIMVER'], imsim.__version__)
+            # Test added_keywords are included correctly
+            self.assertEqual(hdus[0].header['TESTKEY1'], 'TESTVAL1')
+            self.assertEqual(hdus[0].header['TESTKEY2'], 'TESTVAL2')
         os.remove(outfile)
 
     def test_no_opsim(self):

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -39,7 +39,7 @@ class ImageSourceTestCase(unittest.TestCase):
                     'scti': 1.e-6,
                     'added_keywords' : {
                         'TESTKEY1': 'TESTVAL1',
-                        'TESTKEY2': 'TESTVAL2'
+                        'SOMEMATH': '$1+2'
                     }
                 }
             },
@@ -98,7 +98,7 @@ class ImageSourceTestCase(unittest.TestCase):
             self.assertEqual(hdus[0].header['IMSIMVER'], imsim.__version__)
             # Test added_keywords are included correctly
             self.assertEqual(hdus[0].header['TESTKEY1'], 'TESTVAL1')
-            self.assertEqual(hdus[0].header['TESTKEY2'], 'TESTVAL2')
+            self.assertEqual(hdus[0].header['SOMEMATH'], '3')
         os.remove(outfile)
 
     def test_no_opsim(self):


### PR DESCRIPTION
I primarily wanted to get the `PROGRAM` header into the amp files to specify a `science_program` in the butler repository for the data but I think it was cleaner to make something that can accommodate any other optional headers that might be useful in the future.