### PR TITLE
Simplify rotSkyPos calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,25 @@ jobs:
                 pip install -e .
                 cd ..
 
+            - name: Cache data
+              uses: actions/cache@v4
+              with:
+                path: rubin_sim_data
+                key: "2024-05-10"  # Update the key if we ever change the data.
+
             - name: Install rubin_sim_data
               run: |
-                mkdir rubin_sim_data
-                mkdir rubin_sim_data/sims_sed_library
-                # Just get the skybrightness, throughputs, and SED data for now.
-                curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz
-                curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_2023_09_07.tgz | tar -C rubin_sim_data -xz
-                curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz
+                if [ ! -d rubin_sim_data ]; then
+                  echo "Data directory does not exist. Downloading data..."
+                  mkdir rubin_sim_data
+                  mkdir rubin_sim_data/sims_sed_library
+                  # Just get the skybrightness, throughputs, and SED data for now.
+                  curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz
+                  curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_2023_09_07.tgz | tar -C rubin_sim_data -xz
+                  curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz
+                else
+                  echo "Data found in cache. Skipping download."
+                fi
 
             - name: Install imSim
               run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,24 +55,21 @@ jobs:
                 cd ..
 
             - name: Cache data
+              id: cache-data
               uses: actions/cache@v4
               with:
                 path: rubin_sim_data
                 key: "2024-05-10"  # Update the key if we ever change the data.
 
             - name: Install rubin_sim_data
+              if: steps.cache-data.outputs.cache-hit != 'true'
               run: |
-                if [ ! -d rubin_sim_data ]; then
-                  echo "Data directory does not exist. Downloading data..."
-                  mkdir rubin_sim_data
-                  mkdir rubin_sim_data/sims_sed_library
-                  # Just get the skybrightness, throughputs, and SED data for now.
-                  curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz
-                  curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_2023_09_07.tgz | tar -C rubin_sim_data -xz
-                  curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz
-                else
-                  echo "Data found in cache. Skipping download."
-                fi
+                mkdir rubin_sim_data
+                mkdir rubin_sim_data/sims_sed_library
+                # Just get the skybrightness, throughputs, and SED data for now.
+                curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz
+                curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_2023_09_07.tgz | tar -C rubin_sim_data -xz
+                curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz
 
             - name: Install imSim
               run:
@@ -80,14 +77,14 @@ jobs:
 
             - name: Install test deps
               run:
-                conda install -y pytest nose || true
+                conda install -y pytest nose pytest-durations pytest-xdist || true
 
             - name: Run tests
               run: |
                 export RUBIN_SIM_DATA_DIR=`pwd`/rubin_sim_data
                 eups list lsst_distrib
                 galsim --version
-                pytest
+                pytest --durations=10 -n auto
 
             - name: Check example config files
               run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [<img src="https://img.shields.io/badge/dockerhub-imSim image-orange.svg?logo=Docker">](https://hub.docker.com/r/lsstdesc/imsim-env)
-[![Build Status](https://travis-ci.org/LSSTDESC/imSim.svg?branch=main)](https://travis-ci.org/LSSTDESC/imSim)
-[![Coverage Status](https://coveralls.io/repos/github/LSSTDESC/imSim/badge.svg?branch=main)](https://coveralls.io/github/LSSTDESC/imSim?branch=main)
+[![Build Status](https://github.com/LSSTDESC/imSim/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/LSSTDESC/imSim/actions/workflows/ci.yml/badge.svg?branch=main)
 
 # imSim
 imSim is a software package that simulates the LSST telescope and survey.


### PR DESCRIPTION
Updates readout.py:compute_rotSkyPos.

This routine had previously instantiated a complete WCS, marched separate test points a little north, and a little towards the CCD +Y to determine RotSkyPos empirically for insertion into the image header.  The new routine follows notes I made at https://smtn-019.lsst.io/v/DM-44258/index.html, developing something closer to an analytic formula for determining RotSkyPos.  The key insight is that RotSkyPos is intended to relate the camera orientation to _ICRF north_ and not true north.  Previous attempts I've seen at analytic relations use the telescope rotator angle (rotTelPos) and the parallactic angle, the latter being the position angle of zenith measured from true North (not ICRF North). This is the wrong north! So I invented the pseudo-parallactic angle which just swaps true north -> ICRF north.  With that, plus acknowledging a few realities about how telescopes flip images around and other coordinate conventions, the analytic formula for Rubin becomes:

RotSkyPos = 270 - RotTelPos + pseudo-parallactic-angle.

I also clarified the documentation a bit, and fixed one line where the MJD was being interpreted in the (default) UTC time scale instead of the TAI scale.

Note that in the end, I've concluded we _didn't_ make a mistake in simulating OR3.  We were correct to use the regular parallactic angle inside batoid_wcs since the place where we use it relates true-of-date "observed" ra/dec coordinates with altitude and azimuth.  A separate transformation handles true north <-> ICRF north, so we didn't need the pseudo parallactic angle for creating the WCS.