### PR TITLE
Use .withFluxDensity to normalize the SEDs in instcat.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
               run: |
                 git clone https://github.com/LSSTDESC/skyCatalogs.git
                 cd skyCatalogs
-                git checkout v1.6.0rc2
+                git checkout v1.7.0rc4
                 pip install -e .
                 cd ..
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN sed '/stackvana/d' imSim/etc/standalone_conda_requirements.txt > imSim/etc/d
 RUN source /opt/lsst/software/stack/loadLSST.bash &&\
     setup lsst_distrib &&\
     mamba install -y --file imSim/etc/docker_conda_requirements.txt &&\
-    python3 -m pip install batoid skyCatalogs==1.6.0-rc2 gitpython &&\
+    python3 -m pip install batoid skyCatalogs==1.7.0-rc4 gitpython &&\
     python3 -m pip install rubin_sim/ &&\
     python3 -m pip install imSim/
 
@@ -33,7 +33,7 @@ WORKDIR /opt/lsst/software/stack
 # Download Rubin Sim data.
 RUN mkdir -p rubin_sim_data/sims_sed_library
 RUN curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/skybrightness_may_2021.tgz | tar -C rubin_sim_data -xz
-RUN curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_aug_2021.tgz | tar -C rubin_sim_data -xz
+RUN curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/rubin_sim_data/throughputs_2023_09_07.tgz | tar -C rubin_sim_data -xz
 RUN curl https://s3df.slac.stanford.edu/groups/rubin/static/sim-data/sed_library/seds_170124.tar.gz  | tar -C rubin_sim_data/sims_sed_library -xz
 
 # Set location of Rubin sim data (downloaded in step above).

--- a/imsim/instcat.py
+++ b/imsim/instcat.py
@@ -164,10 +164,6 @@ class InstCatalog(object):
 
     The other "phosim commands" are handled by OpsimDataLoader.
     """
-    # Using area-weighted effective aperture over FOV
-    # from https://confluence.lsstcorp.org/display/LKB/LSST+Key+Numbers
-    _rubin_area = 0.25 * np.pi * 649**2  # cm^2
-
     def __init__(self, file_name, wcs, xsize=4096, ysize=4096, sed_dir=None,
                  edge_pix=100, sort_mag=True, flip_g2=True, approx_nobjects=None,
                  pupil_area=RUBIN_AREA, min_source=None, skip_invalid=True,

--- a/imsim/instcat.py
+++ b/imsim/instcat.py
@@ -164,6 +164,10 @@ class InstCatalog(object):
 
     The other "phosim commands" are handled by OpsimDataLoader.
     """
+    # SED normalization for magnorm=0 at 500 nm to be applied to
+    # cached SEDs.
+    fnu = (0 * u.ABmag).to(u.erg/u.s/u.cm**2/u.Hz)
+    _flux_density = fnu.to_value(u.ph/u.nm/u.s/u.cm**2, u.spectral_density(500*u.nm))
     def __init__(self, file_name, wcs, xsize=4096, ysize=4096, sed_dir=None,
                  edge_pix=100, sort_mag=True, flip_g2=True, approx_nobjects=None,
                  pupil_area=RUBIN_AREA, min_source=None, skip_invalid=True,
@@ -354,14 +358,8 @@ class InstCatalog(object):
                               name, self.sed_dir, self.inst_dir))
             sed = galsim.SED(full_name, wave_type='nm', flux_type='flambda')
 
-            # Normalize the SED to magnorm=0 at 500 nm.
-            magnorm = 0.0
-            wl = 500.0*u.nm
-            fnu = (magnorm * u.ABmag).to_value(u.erg/u.s/u.cm**2/u.Hz)
-            flambda = fnu * (astropy.constants.c/wl**2).to_value(u.Hz/u.nm)
-            hnu = (astropy.constants.h * astropy.constants.c / wl).to_value(u.erg)
-            flux_density = flambda / hnu
-            sed = sed.withFluxDensity(flux_density, wl)
+            # Normalize to magnorm=0 at 500 nm.
+            sed = sed.withFluxDensity(self._flux_density, 500.*u.nm)
 
             self._sed_cache[name] = sed
 

--- a/imsim/skycat.py
+++ b/imsim/skycat.py
@@ -9,15 +9,6 @@ from galsim.config import InputLoader, RegisterInputType, RegisterValueType, \
 from skycatalogs import skyCatalogs
 from .utils import RUBIN_AREA
 
-# Hot-fix to set interpolant for 500nm magnorm bandpass in skyCatalogs.
-# Once this is fixed in a skyCatalogs release, we can remove it here.
-import skycatalogs
-import galsim
-bp500 = galsim.Bandpass(
-    galsim.LookupTable([499, 500, 501],[0, 1, 0], interpolant='linear'),
-    wave_type='nm').withZeropoint('AB')
-skycatalogs.objects.base_object.BaseObject._bp500 = bp500
-
 
 class SkyCatalogInterface:
     """Interface to skyCatalogs package."""

--- a/tests/test_instcat_parser.py
+++ b/tests/test_instcat_parser.py
@@ -208,26 +208,6 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
         index = index[np.where(np.in1d(id_arr[index], truth_data['uniqueId']))]
         np.testing.assert_array_equal(truth_data['uniqueId'], id_arr[index])
 
-        ######## test that pupil coordinates are correct to within
-        ######## half a milliarcsecond
-        if 0:
-            # XXX: This test required lsst.sims.  Not sure if we still need it?
-
-            x_pup_test, y_pup_test = _pupilCoordsFromRaDec(truth_data['raJ2000'],
-                                                           truth_data['decJ2000'],
-                                                           pm_ra=truth_data['pmRA'],
-                                                           pm_dec=truth_data['pmDec'],
-                                                           v_rad=truth_data['v_rad'],
-                                                           parallax=truth_data['parallax'],
-                                                           obs_metadata=opsim_data)
-
-            for gs_obj in gs_object_arr:
-                i_obj = np.where(truth_data['uniqueId'] == gs_obj.uniqueId)[0][0]
-                dd = np.sqrt((x_pup_test[i_obj]-gs_obj.xPupilRadians)**2 +
-                             (y_pup_test[i_obj]-gs_obj.yPupilRadians)**2)
-                dd = arcsecFromRadians(dd)
-                self.assertLess(dd, 0.0005)
-
         ######## test that positions are consistent
 
         for det_name in all_wcs:
@@ -269,25 +249,7 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
 
             for i in range(cat.nobjects):
                 obj = cat.getObj(i)
-                if 0:
-                    # XXX: The old test used the sims Sed class.  Circumventing this now,
-                    #      but leaving the old code in case there is a way to use it eventually.
-                    sed = Sed()
-                    i_obj = np.where(truth_data['uniqueId'] == cat.id[i])[0][0]
-                    full_sed_name = os.path.join(sed_dir, truth_data['sedFilename'][i_obj])
-                    sed.readSED_flambda(full_sed_name)
-                    fnorm = sed.calcFluxNorm(truth_data['magNorm'][i_obj], imsim_bp)
-                    sed.multiplyFluxNorm(fnorm)
-                    sed.resampleSED(wavelen_match=bp_dict.wavelenMatch)
-                    a_x, b_x = sed.setupCCM_ab()
-                    sed.addDust(a_x, b_x, A_v=truth_data['Av'][i_obj],
-                                R_v=truth_data['Rv'][i_obj])
-
-                    for bp in ('u', 'g', 'r', 'i', 'z', 'y'):
-                        flux = sed.calcADU(bp_dict[bp], phot_params)*phot_params.gain
-                        self.assertAlmostEqual(flux/gs_obj.flux(bp), 1.0, 10)
-
-                # Instead, this basically recapitulates the calculation in the InstCatalog class.
+                # This basically recapitulates the calculation in the InstCatalog class.
                 magnorm = cat.getMagNorm(i)
                 flux = np.exp(-0.9210340371976184 * magnorm)
                 rubin_area = np.pi * (418**2 - 255**2) # cm^2
@@ -296,35 +258,6 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
                 sed = cat.getSED(i)
                 flux = sed.calculateFlux(bp) * fAt
                 self.assertAlmostEqual(flux, obj.calculateFlux(bp))
-
-        ######## test that objects are assigned to the right chip in
-        ######## gs_object_dict
-
-        if 0:
-            # XXX: This doesn't seem relevant anymore.  But leaving this here in case we want
-            #      to reenable it somehow.
-            unique_id_dict = {}
-            for chip_name in gs_object_dict:
-                local_unique_id_list = []
-                for gs_object in gs_object_dict[chip_name]:
-                    local_unique_id_list.append(gs_object.uniqueId)
-                local_unique_id_list = set(local_unique_id_list)
-                unique_id_dict[chip_name] = local_unique_id_list
-
-            valid = 0
-            valid_chip_names = set()
-            for unq, xpup, ypup in zip(truth_data['uniqueId'],
-                                    truth_data['x_pupil'],
-                                    truth_data['y_pupil']):
-
-                chip_name = chipNameFromPupilCoordsLSST(xpup, ypup)
-                if chip_name is not None:
-                    self.assertIn(unq, unique_id_dict[chip_name])
-                    valid_chip_names.add(chip_name)
-                    valid += 1
-
-            self.assertGreater(valid, 10)
-            self.assertGreater(len(valid_chip_names), 5)
 
     def test_object_extraction_galaxies(self):
         """
@@ -447,31 +380,8 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
                 i_obj = np.where(truth_data['uniqueId'] == cat.id[i])[0]
                 if len(i_obj) == 0: continue
                 i_obj = i_obj[0]
-                if 0:
-                    # XXX: The old test using the sims Sed class.
-                    #      Saved in case it becomes reasonable to use it again.
-                    sed = Sed()
-                    full_sed_name = os.path.join(os.environ['SIMS_SED_LIBRARY_DIR'],
-                                                truth_data['sedFilename'][i_obj])
-                    sed.readSED_flambda(full_sed_name)
-                    fnorm = sed.calcFluxNorm(truth_data['magNorm'][i_obj], imsim_bp)
-                    sed.multiplyFluxNorm(fnorm)
 
-                    a_x, b_x = sed.setupCCM_ab()
-                    sed.addDust(a_x, b_x, A_v=truth_data['internalAv'][i_obj],
-                                R_v=truth_data['internalRv'][i_obj])
-
-                    sed.redshiftSED(truth_data['redshift'][i_obj], dimming=True)
-                    sed.resampleSED(wavelen_match=bp_dict.wavelenMatch)
-                    a_x, b_x = sed.setupCCM_ab()
-                    sed.addDust(a_x, b_x, A_v=truth_data['galacticAv'][i_obj],
-                                R_v=truth_data['galacticRv'][i_obj])
-
-                    for bp in ('u', 'g', 'r', 'i', 'z', 'y'):
-                        flux = sed.calcADU(bp_dict[bp], phot_params)*phot_params.gain
-                        self.assertAlmostEqual(flux/gs_obj.flux(bp), 1.0, 6)
-
-                # Instead, this basically recapitulates the calculation in the InstCatalog class.
+                # This basically recapitulates the calculation in the InstCatalog class.
                 magnorm = cat.getMagNorm(i)
                 flux = np.exp(-0.9210340371976184 * magnorm)
                 rubin_area = np.pi * (418**2 - 255**2) # cm^2
@@ -481,34 +391,6 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
                 # TODO: We aren't applying dust terms currently.
                 flux = sed.calculateFlux(bp) * fAt
                 self.assertAlmostEqual(flux, obj.calculateFlux(bp))
-
-        ######## test that objects are assigned to the right chip in
-        ######## gs_object_dict
-
-        if 0:
-            # XXX: Skipping this again.
-            unique_id_dict = {}
-            for chip_name in gs_object_dict:
-                local_unique_id_list = []
-                for gs_object in gs_object_dict[chip_name]:
-                    local_unique_id_list.append(gs_object.uniqueId)
-                local_unique_id_list = set(local_unique_id_list)
-                unique_id_dict[chip_name] = local_unique_id_list
-
-            valid = 0
-            valid_chip_names = set()
-            for unq, xpup, ypup in zip(truth_data['uniqueId'],
-                                    truth_data['x_pupil'],
-                                    truth_data['y_pupil']):
-
-                chip_name = chipNameFromPupilCoordsLSST(xpup, ypup)
-                if chip_name is not None:
-                    self.assertIn(unq, unique_id_dict[chip_name])
-                    valid_chip_names.add(chip_name)
-                    valid += 1
-
-            self.assertGreater(valid, 10)
-            self.assertGreater(len(valid_chip_names), 5)
 
     def test_photometricParameters(self):
         "Test the photometricParameters function."


### PR DESCRIPTION
I also cleaned up a couple of no-longer relevant hot-fixes related to the SED normalization in skyCatalogs, and I removed the old, disabled test code in test_instcat_parser.py since it all relied on lsst.sims functionality.