### PR TITLE
doc fixes

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -155,7 +155,8 @@ Now we are ready to install *imSim*. First go to the directory where you would l
 
    # Install imSim:
    pip install --no-deps imSim/
-   pip install --no-deps skyCatalogs/
+   # turn off build isolation for newer pip
+   pip install --no-build-isolation --no-deps skyCatalogs/
 
 Install *rubin_sim_data*
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -180,6 +181,7 @@ Set runtime environment variables for the *Conda* environment
 
 .. code-block:: sh
 
+    conda env config vars set IMSIM_HOME=/path/to/imSim-git-repo
     conda env config vars set RUBIN_SIM_DATA_DIR=$(pwd)/rubin_sim_data
     conda env config vars set SIMS_SED_LIBRARY_DIR=$(pwd)/rubin_sim_data/sims_sed_library
 


### PR DESCRIPTION
- Indicate setting IMSIM_HOME for conda install
- modify pip install for skyCatalogs.  --no-build-isolation is needed for newer pip.  See https://github.com/LSSTDESC/skyCatalogs/issues/101