### PR TITLE
Correct sky_pos and local_wcs in photon op tests

### DIFF
--- a/tests/test_photon_ops.py
+++ b/tests/test_photon_ops.py
@@ -632,6 +632,7 @@ def test_config_rubin_optics():
     """Check the config interface to RubinOptics."""
 
     image_pos = galsim.PositionD(3076.4462608524213, 1566.4896702703757)
+    boresight = galsim.CelestialCoord(1.1047934165124105 * galsim.radians, -0.5261230452954583 * galsim.radians)
     config = {
         **deepcopy(TEST_BASE_CONFIG),
         "image_pos": image_pos,  # This would get set appropriately during normal config processing.
@@ -641,16 +642,12 @@ def test_config_rubin_optics():
                     "type": "RubinOptics",
                     "camera": "LsstCam",
                     "det_name": "R22_S11",
-                    "boresight": {
-                        "type": "RADec",
-                        "ra": "1.1047934165124105 radians",
-                        "dec": "-0.5261230452954583 radians",
-                    },
+                    "boresight": boresight,
                 },
             ]
         },
         "sky_pos": create_test_img_wcs(
-            boresight=galsim.CelestialCoord(1.1047934165124105 * galsim.radians, -0.5261230452954583 * galsim.radians),
+            boresight=boresight,
             rottelpos=np.pi / 3 * galsim.radians
         ).toWorld(image_pos),
     }


### PR DESCRIPTION
Some of the photon op tests appear not to be self-consistent: the `sky_pos` and `local_wcs` are set independently though both should actually be derived from the image's WCS and the object position within it. This wouldn't be an issue except that the incoming PR #424 implements a new `XyToV` which is self-consistent through use of the `img_wcs` alone and so breaks the regression tests here. This PR updates the tests to calculate the the `sky_pos` and `local_wcs` together from the `image_pos` and `img_wcs`.

Note this isn't an issue in the photon ops themselves, just in the test method. This also changes the expected photon position centre in the regression tests from (-564.5, -1431.4) to (-960.28, -308.09). This is borne out in the tests in PR #424 using the new `XyToV` implementation which preserves these results.