### PR TITLE
Remove test using calculateFWHM from test_atm_psf_fft

### DIFF
--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -419,8 +419,6 @@ class PsfTestCase(unittest.TestCase):
 
         print('Peak of reference PSF (flux=1.e5): ',ref_img.array.max())
         print('Peak of FFT PSF (flux=1.e8): ',img.array.max())
-        print('FWHM of reference PSF: ',ref_img.view(scale=0.2).calculateFWHM())
-        print('FWHM of FFT PSF: ',img.view(scale=0.2).calculateFWHM())
         print('Rmom of reference PSF: ',ref_img.view(scale=0.2).calculateMomentRadius())
         print('Rmom of FFT PSF: ',img.view(scale=0.2).calculateMomentRadius())
 
@@ -432,8 +430,6 @@ class PsfTestCase(unittest.TestCase):
         np.testing.assert_allclose(ref_img.array.max(), img.array.max(), rtol=0.05)
 
         # The sizes should also be pretty close
-        np.testing.assert_allclose(ref_img.view(scale=0.2).calculateFWHM(),
-                                   img.view(scale=0.2).calculateFWHM(), rtol=0.08)
         np.testing.assert_allclose(ref_img.view(scale=0.2).calculateMomentRadius(),
                                    img.view(scale=0.2).calculateMomentRadius(), rtol=0.1)
 


### PR DESCRIPTION
In #493 we found an issue with `calculateFWHM()` as used in one of the PSF tests. This is now being fixed in GalSim (https://github.com/GalSim-developers/GalSim/pull/1337) but in the meantime @rmjarvis has suggested removing the lines calculating and testing the FWHM in the imSim test as there are already assertions that the size is as expected using `calculateMomentRadius()`. This PR simply removes the references to the FWHM and the assertion.

Once this is merged into main, I'll rebase #493 onto it and push again.